### PR TITLE
feat: inline Stripe Payment Element with Express Checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ HAPPINESS_ROOT_API_KEY=''
 # A URL to the database, ideally a PlanetScale database URL ending with ?ssl={"rejectUnauthorized":true}
 DATABASE_URL=''
 
+# The Stripe publishable key for the platform (client-side)
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=''
+
 # The Stripe secret key for the platform
 STRIPE_SECRET_KEY=''
 

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ STRIPE_SECRET_KEY=''
 # The Stripe account ID. Only needed if you want to send all requests through a Stripe Connect account using your platform secret key
 STRIPE_ACCOUNT_ID=''
 
+# The same Stripe Connect account ID, exposed to the client for Stripe.js. Must match STRIPE_ACCOUNT_ID if set.
+NEXT_PUBLIC_STRIPE_ACCOUNT_ID=''
+
 # The public-facing name for this platform
 NEXT_PUBLIC_APP_NAME=''
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     transpilePackages: ['paris'],
+    env: {
+        NEXT_PUBLIC_STRIPE_ACCOUNT_ID: process.env.STRIPE_ACCOUNT_ID || '',
+    },
     webpack: (config) => {
         config.module.rules.push({
             test: /\.svg$/i,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
         "@ssh/csstypes": "^1.1.0",
         "@ssh/eslint-config": "^1.0.0",
         "@stoplight/elements": "^7.10.0",
+        "@stripe/react-stripe-js": "^5.6.1",
+        "@stripe/stripe-js": "^8.11.0",
         "@svgr/webpack": "^8.1.0",
         "@types/node": "20.5.8",
         "@types/react": "18.2.21",

--- a/src/app/(api)/api/layout.tsx
+++ b/src/app/(api)/api/layout.tsx
@@ -1,21 +1,18 @@
 import type { ReactNode } from 'react';
 import Script from 'next/script';
 import * as fs from 'fs';
-import {
-    Fira_Code, Inter,
-} from 'next/font/google';
+import { Fira_Code } from 'next/font/google';
 
 export const runtime = 'nodejs';
 
-const inter = Inter({ subsets: ['latin'], display: 'swap' });
 const code = Fira_Code({ subsets: ['latin'], display: 'swap' });
 const customStyles = `a[href^="https://stoplight"] {
     display: none;
 }
 
 :root {
-    --font-prose: ${inter.style.fontFamily}, -apple-system, ui-sans-serif, system-ui, sans-serif;
-    --font-ui: ${inter.style.fontFamily}, -apple-system, ui-sans-serif, system-ui, sans-serif;
+    --font-prose: -apple-system, ui-sans-serif, system-ui, sans-serif;
+    --font-ui: -apple-system, ui-sans-serif, system-ui, sans-serif;
     --font-code: ${code.style.fontFamily}, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     --font-mono: ${code.style.fontFamily}, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }`;

--- a/src/app/(api)/layout.tsx
+++ b/src/app/(api)/layout.tsx
@@ -1,11 +1,8 @@
 import 'src/app/globals.css';
 import 'paris/theme/global.scss';
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { HappinessConfig } from 'happiness.config';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const runtime = 'nodejs';
 
@@ -24,7 +21,7 @@ export default function RootLayout({
             <head>
                 <link rel="shortcut icon" href={HappinessConfig.favicon} />
             </head>
-            <body className={inter.className}>
+            <body>
                 {children}
                 <SpeedInsights />
             </body>

--- a/src/app/(api)/v1/donations/checkout/DonationConfig.ts
+++ b/src/app/(api)/v1/donations/checkout/DonationConfig.ts
@@ -19,6 +19,8 @@ export type DonationConfig = {
     pageID: string;
     /** Tip for the platform. */
     tipPercent: number;
+    /** Donor email for receipts. */
+    email: string;
 };
 
 export const DonationConfigSchema = z.object({
@@ -30,6 +32,7 @@ export const DonationConfigSchema = z.object({
     projectName: z.string(),
     pageID: z.string(),
     tipPercent: z.number().gte(0),
+    email: z.string().email(),
 });
 
 const estFeePercent = 0.029 + HappinessConfig.platformFee;

--- a/src/app/(api)/v1/donations/create-intent/route.ts
+++ b/src/app/(api)/v1/donations/create-intent/route.ts
@@ -24,6 +24,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
             visible: `${!validated.anonymous}`,
             tipAmount: `${tipAmount}`,
             donationID,
+            email: validated.email,
             ...validated.message ? { message: validated.message } : {},
         };
 
@@ -36,6 +37,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                 currency: 'usd',
                 metadata,
                 description,
+                receipt_email: validated.email,
                 automatic_payment_methods: { enabled: true },
             });
 
@@ -57,6 +59,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
             : null;
 
         const customer = await stripe.customers.create({
+            email: validated.email,
             metadata: { createdByHappiness: 'true' },
         });
 

--- a/src/app/(api)/v1/donations/create-intent/route.ts
+++ b/src/app/(api)/v1/donations/create-intent/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { handleErrors } from '@v1/responses/handleErrors';
+import { stripe } from '@lib/stripe';
+import { DonationConfigSchema } from '@v1/donations/checkout/DonationConfig';
+import { HappinessConfig } from 'happiness.config';
+import { generateID, Prefixes } from 'src/util/generateID';
+import { HappinessError } from 'src/util/HappinessError';
+
+export const POST = async (request: NextRequest): Promise<NextResponse> => {
+    try {
+        const body = await request.json();
+        const validated = await DonationConfigSchema.parseAsync(body);
+
+        const donationID = generateID(Prefixes.Donation);
+        const isRecurring = validated.frequency === 'Monthly';
+
+        const tipAmount = Math.round(validated.tipPercent * validated.amount);
+        const totalAmount = validated.amount + tipAmount;
+
+        const metadata = {
+            createdByHappiness: 'true',
+            pageID: validated.pageID,
+            visible: `${!validated.anonymous}`,
+            tipAmount: `${tipAmount}`,
+            donationID,
+            ...validated.message ? { message: validated.message } : {},
+        };
+
+        const description = `Donation to ${validated.projectName}`;
+
+        if (!isRecurring) {
+            // One-time donation: create a PaymentIntent
+            const paymentIntent = await stripe.paymentIntents.create({
+                amount: totalAmount,
+                currency: 'usd',
+                metadata,
+                description,
+                automatic_payment_methods: { enabled: true },
+            });
+
+            if (!paymentIntent.client_secret) {
+                throw new HappinessError('Failed to create payment intent', 500);
+            }
+
+            return NextResponse.json({
+                clientSecret: paymentIntent.client_secret,
+                donationID,
+            });
+        }
+
+        // Recurring donation: create Products, Customer, and Subscription
+        // Subscription price_data requires product IDs (not inline product_data)
+        const donationProduct = await stripe.products.create({ name: 'Donation', description });
+        const tipProduct = tipAmount > 0
+            ? await stripe.products.create({ name: 'Tip', description: `Supporting ${HappinessConfig.name}` })
+            : null;
+
+        const customer = await stripe.customers.create({
+            metadata: { createdByHappiness: 'true' },
+        });
+
+        const subscription = await stripe.subscriptions.create({
+            customer: customer.id,
+            items: [
+                {
+                    price_data: {
+                        unit_amount: validated.amount,
+                        currency: 'usd',
+                        product: donationProduct.id,
+                        recurring: { interval: 'month' },
+                    },
+                },
+                ...(tipAmount > 0 && tipProduct ? [{
+                    price_data: {
+                        unit_amount: tipAmount,
+                        currency: 'usd',
+                        product: tipProduct.id,
+                        recurring: { interval: 'month' as const },
+                    },
+                }] : []),
+            ],
+            payment_behavior: 'default_incomplete',
+            payment_settings: {
+                save_default_payment_method: 'on_subscription',
+            },
+            metadata,
+            expand: ['latest_invoice.payment_intent'],
+        });
+
+        const invoice = subscription.latest_invoice;
+        if (!invoice || typeof invoice === 'string') {
+            throw new HappinessError('Failed to create subscription invoice', 500);
+        }
+        const pi = invoice.payment_intent;
+        if (!pi || typeof pi === 'string' || !pi.client_secret) {
+            throw new HappinessError('Failed to create subscription payment intent', 500);
+        }
+
+        return NextResponse.json({
+            clientSecret: pi.client_secret,
+            donationID,
+        });
+    } catch (e) {
+        return handleErrors(e);
+    }
+};

--- a/src/app/(api)/v1/external/stripe/route.ts
+++ b/src/app/(api)/v1/external/stripe/route.ts
@@ -26,7 +26,78 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
         const event = await stripe.webhooks.constructEventAsync(await request.text(), whSec, stripeWebhookSecret);
 
         switch (event.type) {
-            // We always create invoices for donations, so we can rely on the invoice events
+            // One-time donations via inline Payment Element create PaymentIntents directly
+            case 'payment_intent.succeeded': {
+                const pi = event.data.object as Stripe.PaymentIntent;
+
+                // Skip subscription-originated PIs — they're handled by invoice.paid
+                if (pi.invoice) {
+                    return new NextResponse(null, { status: 202 });
+                }
+
+                // Validate the metadata to ensure it's Happiness-created
+                const validatePiMetadata = await z
+                    .object({
+                        createdByHappiness: z.literal('true'),
+                        pageID: z.string(),
+                        donationID: z.string(),
+                        message: z.string().optional(),
+                        visible: z.string().optional(),
+                        tipAmount: z.string().optional(),
+                    })
+                    .passthrough()
+                    .spa(pi.metadata);
+
+                if (!validatePiMetadata.success) {
+                    // Not a Happiness transaction — ignore
+                    return new NextResponse(null, { status: 202 });
+                }
+
+                const piMeta = validatePiMetadata.data;
+
+                // Retrieve the charge with balance transaction for fee info
+                const piExpanded = await stripe.paymentIntents.retrieve(pi.id, {
+                    expand: ['latest_charge.balance_transaction', 'customer'],
+                });
+                const customer = piExpanded.customer as Stripe.Customer | null;
+                const charge = piExpanded.latest_charge as Stripe.Charge;
+                const balanceTx = charge.balance_transaction as Stripe.BalanceTransaction;
+
+                if (customer?.email) {
+                    await stripe.paymentIntents.update(pi.id, {
+                        receipt_email: customer.email,
+                    }).catch((e) => {
+                        console.error('Failed to update payment intent receipt email:', e);
+                    });
+                }
+
+                const piDonation = await upsertDonation(
+                    {
+                        id: piMeta.donationID,
+                        pageID: piMeta.pageID,
+                        message: piMeta.message,
+                        visible: piMeta.visible === 'true',
+                        amount: (piExpanded.amount_received - Number(piMeta.tipAmount || 0)),
+                        amountCurrency: piExpanded.currency,
+                        fee: balanceTx.fee,
+                        feeCurrency: balanceTx.currency,
+                        externalTransactionProvider: 'stripe',
+                        externalTransactionID: piExpanded.id,
+                        tipAmount: Number(piMeta.tipAmount || 0),
+                    },
+                    {
+                        firstName: customer?.name?.split(' ')[0] || 'Anonymous',
+                        lastName: customer?.name?.split(' ')[1] || 'Donor',
+                        email: customer?.email || null,
+                        phone: customer?.phone || null,
+                        anonymous: piMeta.visible !== 'true',
+                    },
+                );
+
+                return NextResponse.json(piDonation, { status: 201 });
+            }
+
+            // Subscriptions (monthly donations) still use invoice events
             case 'invoice.paid': {
                 const invoice = event.data.object as Stripe.Invoice;
 
@@ -97,7 +168,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                         lastName: customer?.name?.split(' ')[1] || 'Donor',
                         email: customer.email,
                         phone: customer.phone || null,
-                        anonymous: metadata.visible === 'true',
+                        anonymous: metadata.visible !== 'true',
                     },
                 );
 

--- a/src/app/(api)/v1/external/stripe/route.ts
+++ b/src/app/(api)/v1/external/stripe/route.ts
@@ -44,6 +44,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                         message: z.string().optional(),
                         visible: z.string().optional(),
                         tipAmount: z.string().optional(),
+                        email: z.string().optional(),
                     })
                     .passthrough()
                     .spa(pi.metadata);
@@ -71,6 +72,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                     });
                 }
 
+                const donorEmail = piMeta.email
+                    || charge.billing_details?.email
+                    || customer?.email
+                    || `${piMeta.donationID}@donor.noemail`;
+
                 const piDonation = await upsertDonation(
                     {
                         id: piMeta.donationID,
@@ -88,7 +94,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                     {
                         firstName: customer?.name?.split(' ')[0] || 'Anonymous',
                         lastName: customer?.name?.split(' ')[1] || 'Donor',
-                        email: customer?.email || null,
+                        email: donorEmail,
                         phone: customer?.phone || null,
                         anonymous: piMeta.visible !== 'true',
                     },
@@ -113,6 +119,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                         message: z.string().optional(),
                         visible: z.string().optional(),
                         tipAmount: z.string().optional(),
+                        email: z.string().optional(),
                     })
                     .passthrough()
                     .spa(
@@ -148,6 +155,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                         });
                 }
 
+                const invoiceDonorEmail = metadata.email
+                    || customer?.email
+                    || charge.billing_details?.email
+                    || `${donationID}@donor.noemail`;
+
                 // Upsert donation
                 const donation = await upsertDonation(
                     {
@@ -166,8 +178,8 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                     {
                         firstName: customer?.name?.split(' ')[0] || 'Anonymous',
                         lastName: customer?.name?.split(' ')[1] || 'Donor',
-                        email: customer.email,
-                        phone: customer.phone || null,
+                        email: invoiceDonorEmail,
+                        phone: customer?.phone || null,
                         anonymous: metadata.visible !== 'true',
                     },
                 );

--- a/src/app/(frontend)/[pageID]/Banner.tsx
+++ b/src/app/(frontend)/[pageID]/Banner.tsx
@@ -28,7 +28,7 @@ export const Banner: FC<BannerProps> = ({
                 <img
                     src={url}
                     alt={alt}
-                    className="max-w-full max-h-full object-contain z-[1]"
+                    className="max-w-full max-h-full h-full object-contain z-[1]"
                 />
             </div>
         )}

--- a/src/app/(frontend)/[pageID]/CheckoutForm.tsx
+++ b/src/app/(frontend)/[pageID]/CheckoutForm.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import {
+    PaymentElement,
+    useStripe,
+    useElements,
+} from '@stripe/react-stripe-js';
+import { Button } from 'paris/button';
+import { Text } from 'paris/text';
+import { formatCurrency } from 'src/util/formatCurrency';
+import type { DonationConfig } from '@v1/donations/checkout/DonationConfig';
+import { estimateFee } from '@v1/donations/checkout/DonationConfig';
+
+export const CheckoutForm = ({
+    donation,
+    onSuccess,
+    returnUrl,
+}: {
+    donation: DonationConfig;
+    onSuccess: () => void;
+    returnUrl: string;
+}) => {
+    const stripe = useStripe();
+    const elements = useElements();
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    const estFee = estimateFee(donation.amount);
+    const feeAmount = donation.coverFees ? estFee : 0;
+    const tipAmount = Math.round((donation.amount + feeAmount) * donation.tipPercent);
+    const total = donation.amount + feeAmount + tipAmount;
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!stripe || !elements) return;
+
+        setLoading(true);
+        setError(null);
+
+        // Validate payment details
+        const { error: submitError } = await elements.submit();
+        if (submitError) {
+            setError(submitError.message ?? 'Validation failed');
+            setLoading(false);
+            return;
+        }
+
+        // Create the PaymentIntent/Subscription on the server
+        const res = await fetch('/v1/donations/create-intent', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                ...donation,
+                amount: donation.amount + feeAmount,
+            }),
+        });
+
+        if (!res.ok) {
+            const data = await res.json().catch(() => null);
+            setError(data?.message ?? 'Failed to create payment. Please try again.');
+            setLoading(false);
+            return;
+        }
+
+        const { clientSecret } = await res.json();
+
+        // Confirm the payment
+        const { error: confirmError } = await stripe.confirmPayment({
+            elements,
+            clientSecret,
+            confirmParams: {
+                return_url: returnUrl,
+            },
+            redirect: 'if_required',
+        });
+
+        if (confirmError) {
+            setError(confirmError.message ?? 'Payment failed. Please try again.');
+            setLoading(false);
+            return;
+        }
+
+        // Payment succeeded inline
+        onSuccess();
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="w-full flex flex-col gap-6">
+            <div className="flex flex-col gap-3">
+                <Text kind="paragraphSmall" style={{ fontWeight: 500 }}>
+                    Order Summary
+                </Text>
+                <div className="flex flex-col gap-1">
+                    <div className="flex justify-between">
+                        <Text kind="paragraphXSmall">Donation</Text>
+                        <Text kind="paragraphXSmall">{formatCurrency(donation.amount, 2)}</Text>
+                    </div>
+                    {donation.coverFees && (
+                        <div className="flex justify-between">
+                            <Text kind="paragraphXSmall">Processing fees</Text>
+                            <Text kind="paragraphXSmall">{formatCurrency(feeAmount, 2)}</Text>
+                        </div>
+                    )}
+                    {tipAmount > 0 && (
+                        <div className="flex justify-between">
+                            <Text kind="paragraphXSmall">Tip ({donation.tipPercent * 100}%)</Text>
+                            <Text kind="paragraphXSmall">{formatCurrency(tipAmount, 2)}</Text>
+                        </div>
+                    )}
+                    <div
+                        className="flex justify-between pt-2 mt-1"
+                        style={{ borderTop: '1px solid var(--border-color, #e5e5e5)' }}
+                    >
+                        <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>Total</Text>
+                        <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>
+                            {formatCurrency(total, 2)}
+                            {donation.frequency !== 'One-time' ? ' / month' : ''}
+                        </Text>
+                    </div>
+                </div>
+            </div>
+
+            <PaymentElement options={{ layout: 'accordion' }} />
+
+            {error && (
+                <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
+                    {error}
+                </Text>
+            )}
+
+            <Button
+                type="submit"
+                disabled={!stripe || !elements || loading}
+            >
+                {loading
+                    ? 'Processing...'
+                    : `Donate ${formatCurrency(total, 2)}${donation.frequency !== 'One-time' ? ' / month' : ''}`}
+            </Button>
+        </form>
+    );
+};

--- a/src/app/(frontend)/[pageID]/CheckoutForm.tsx
+++ b/src/app/(frontend)/[pageID]/CheckoutForm.tsx
@@ -104,7 +104,9 @@ export const CheckoutForm = ({
                     )}
                     {tipAmount > 0 && (
                         <div className="flex justify-between">
-                            <Text kind="paragraphXSmall">Tip ({donation.tipPercent * 100}%)</Text>
+                            <Text kind="paragraphXSmall">
+                                {`Tip (${donation.tipPercent * 100}%)`}
+                            </Text>
                             <Text kind="paragraphXSmall">{formatCurrency(tipAmount, 2)}</Text>
                         </div>
                     )}

--- a/src/app/(frontend)/[pageID]/CheckoutForm.tsx
+++ b/src/app/(frontend)/[pageID]/CheckoutForm.tsx
@@ -1,144 +1,190 @@
 'use client';
 
-import { useState } from 'react';
+import {
+    forwardRef, useEffect, useState,
+} from 'react';
 import {
     PaymentElement,
+    ExpressCheckoutElement,
     useStripe,
     useElements,
 } from '@stripe/react-stripe-js';
-import { Button } from 'paris/button';
+import type {
+    StripeExpressCheckoutElementConfirmEvent,
+} from '@stripe/stripe-js';
 import { Text } from 'paris/text';
 import { formatCurrency } from 'src/util/formatCurrency';
 import type { DonationConfig } from '@v1/donations/checkout/DonationConfig';
 import { estimateFee } from '@v1/donations/checkout/DonationConfig';
 
-export const CheckoutForm = ({
-    donation,
-    onSuccess,
-    returnUrl,
-}: {
+export const CheckoutForm = forwardRef<
+HTMLFormElement,
+{
     donation: DonationConfig;
     onSuccess: () => void;
     returnUrl: string;
-}) => {
-    const stripe = useStripe();
-    const elements = useElements();
-    const [error, setError] = useState<string | null>(null);
-    const [loading, setLoading] = useState(false);
+    onLoadingChange?: (loading: boolean) => void;
+}
+>(({
+            donation,
+            onSuccess,
+            returnUrl,
+            onLoadingChange,
+        }, ref) => {
+            const stripe = useStripe();
+            const elements = useElements();
+            const [error, setError] = useState<string | null>(null);
+            const [loading, setLoading] = useState(false);
 
-    const estFee = estimateFee(donation.amount);
-    const feeAmount = donation.coverFees ? estFee : 0;
-    const tipAmount = Math.round((donation.amount + feeAmount) * donation.tipPercent);
-    const total = donation.amount + feeAmount + tipAmount;
+            const estFee = estimateFee(donation.amount);
+            const feeAmount = donation.coverFees ? estFee : 0;
+            const tipAmount = Math.round((donation.amount + feeAmount) * donation.tipPercent);
+            const total = donation.amount + feeAmount + tipAmount;
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!stripe || !elements) return;
+            useEffect(() => {
+                onLoadingChange?.(loading);
+            }, [loading, onLoadingChange]);
 
-        setLoading(true);
-        setError(null);
+            const createIntentAndConfirm = async () => {
+                if (!stripe || !elements) return;
 
-        // Validate payment details
-        const { error: submitError } = await elements.submit();
-        if (submitError) {
-            setError(submitError.message ?? 'Validation failed');
-            setLoading(false);
-            return;
-        }
+                const { error: submitError } = await elements.submit();
+                if (submitError) {
+                    throw new Error(submitError.message ?? 'Validation failed');
+                }
 
-        // Create the PaymentIntent/Subscription on the server
-        const res = await fetch('/v1/donations/create-intent', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                ...donation,
-                amount: donation.amount + feeAmount,
-            }),
-        });
+                const res = await fetch('/v1/donations/create-intent', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        ...donation,
+                        amount: donation.amount + feeAmount,
+                    }),
+                });
 
-        if (!res.ok) {
-            const data = await res.json().catch(() => null);
-            setError(data?.message ?? 'Failed to create payment. Please try again.');
-            setLoading(false);
-            return;
-        }
+                if (!res.ok) {
+                    const data = await res.json().catch(() => null);
+                    throw new Error(data?.message ?? 'Failed to create payment.');
+                }
 
-        const { clientSecret } = await res.json();
+                const { clientSecret } = await res.json();
 
-        // Confirm the payment
-        const { error: confirmError } = await stripe.confirmPayment({
-            elements,
-            clientSecret,
-            confirmParams: {
-                return_url: returnUrl,
-            },
-            redirect: 'if_required',
-        });
+                const { error: confirmError } = await stripe.confirmPayment({
+                    elements,
+                    clientSecret,
+                    confirmParams: {
+                        return_url: returnUrl,
+                    },
+                    redirect: 'if_required',
+                });
 
-        if (confirmError) {
-            setError(confirmError.message ?? 'Payment failed. Please try again.');
-            setLoading(false);
-            return;
-        }
+                if (confirmError) {
+                    throw new Error(confirmError.message ?? 'Payment failed.');
+                }
 
-        // Payment succeeded inline
-        onSuccess();
-    };
+                onSuccess();
+            };
 
-    return (
-        <form onSubmit={handleSubmit} className="w-full flex flex-col gap-6">
-            <div className="flex flex-col gap-3">
-                <Text kind="paragraphSmall" style={{ fontWeight: 500 }}>
-                    Order Summary
-                </Text>
-                <div className="flex flex-col gap-1">
-                    <div className="flex justify-between">
-                        <Text kind="paragraphXSmall">Donation</Text>
-                        <Text kind="paragraphXSmall">{formatCurrency(donation.amount, 2)}</Text>
-                    </div>
-                    {donation.coverFees && (
-                        <div className="flex justify-between">
-                            <Text kind="paragraphXSmall">Processing fees</Text>
-                            <Text kind="paragraphXSmall">{formatCurrency(feeAmount, 2)}</Text>
-                        </div>
-                    )}
-                    {tipAmount > 0 && (
-                        <div className="flex justify-between">
-                            <Text kind="paragraphXSmall">
-                                {`Tip (${donation.tipPercent * 100}%)`}
-                            </Text>
-                            <Text kind="paragraphXSmall">{formatCurrency(tipAmount, 2)}</Text>
-                        </div>
-                    )}
-                    <div
-                        className="flex justify-between pt-2 mt-1"
-                        style={{ borderTop: '1px solid var(--border-color, #e5e5e5)' }}
-                    >
-                        <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>Total</Text>
-                        <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>
-                            {formatCurrency(total, 2)}
-                            {donation.frequency !== 'One-time' ? ' / month' : ''}
+            const handleSubmit = async (e: React.FormEvent) => {
+                e.preventDefault();
+                setLoading(true);
+                setError(null);
+                try {
+                    await createIntentAndConfirm();
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : 'Payment failed.');
+                    setLoading(false);
+                }
+            };
+
+            const handleExpressConfirm = async (
+                event: StripeExpressCheckoutElementConfirmEvent,
+            ) => {
+                setLoading(true);
+                setError(null);
+                try {
+                    await createIntentAndConfirm();
+                } catch (err) {
+                    event.paymentFailed({ reason: 'fail' });
+                    setError(err instanceof Error ? err.message : 'Payment failed.');
+                    setLoading(false);
+                }
+            };
+
+            return (
+                <form ref={ref} onSubmit={handleSubmit} className="w-full flex flex-col gap-6">
+                    <div className="flex flex-col gap-3">
+                        <Text kind="paragraphSmall" style={{ fontWeight: 500 }}>
+                            Order Summary
                         </Text>
+                        <div className="flex flex-col gap-1">
+                            <div className="flex justify-between">
+                                <Text kind="paragraphXSmall">Donation</Text>
+                                <Text kind="paragraphXSmall">{formatCurrency(donation.amount, 2)}</Text>
+                            </div>
+                            {donation.coverFees && (
+                                <div className="flex justify-between">
+                                    <Text kind="paragraphXSmall">Processing fees</Text>
+                                    <Text kind="paragraphXSmall">{formatCurrency(feeAmount, 2)}</Text>
+                                </div>
+                            )}
+                            {tipAmount > 0 && (
+                                <div className="flex justify-between">
+                                    <Text kind="paragraphXSmall">
+                                        {`Tip (${donation.tipPercent * 100}%)`}
+                                    </Text>
+                                    <Text kind="paragraphXSmall">{formatCurrency(tipAmount, 2)}</Text>
+                                </div>
+                            )}
+                            <div
+                                className="flex justify-between pt-2 mt-1"
+                                style={{ borderTop: '1px solid var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                            >
+                                <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>Total</Text>
+                                <Text kind="paragraphSmall" style={{ fontWeight: 600 }}>
+                                    {formatCurrency(total, 2)}
+                                    {donation.frequency !== 'One-time' ? ' / month' : ''}
+                                </Text>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
 
-            <PaymentElement options={{ layout: 'accordion' }} />
+                    <ExpressCheckoutElement
+                        onConfirm={handleExpressConfirm}
+                        options={{
+                            buttonType: {
+                                applePay: 'donate',
+                                googlePay: 'donate',
+                            },
+                        }}
+                    />
 
-            {error && (
-                <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
-                    {error}
-                </Text>
-            )}
+                    <div className="flex items-center gap-3">
+                        <div
+                            className="flex-1 h-px"
+                            style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                        />
+                        <Text
+                            kind="paragraphXSmall"
+                            style={{ color: 'var(--pte-colors-contentTertiary, #6b7280)' }}
+                        >
+                            Or pay with card
+                        </Text>
+                        <div
+                            className="flex-1 h-px"
+                            style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                        />
+                    </div>
 
-            <Button
-                type="submit"
-                disabled={!stripe || !elements || loading}
-            >
-                {loading
-                    ? 'Processing...'
-                    : `Donate ${formatCurrency(total, 2)}${donation.frequency !== 'One-time' ? ' / month' : ''}`}
-            </Button>
-        </form>
-    );
-};
+                    <PaymentElement options={{ layout: 'accordion' }} />
+
+                    {error && (
+                        <Text kind="paragraphXSmall" style={{ color: 'var(--pte-colors-contentNegative, #dc2626)' }}>
+                            {error}
+                        </Text>
+                    )}
+                </form>
+            );
+        });
+
+CheckoutForm.displayName = 'CheckoutForm';

--- a/src/app/(frontend)/[pageID]/CheckoutForm.tsx
+++ b/src/app/(frontend)/[pageID]/CheckoutForm.tsx
@@ -12,6 +12,7 @@ import {
 import type {
     StripeExpressCheckoutElementConfirmEvent,
 } from '@stripe/stripe-js';
+import { Input } from 'paris/input';
 import { Text } from 'paris/text';
 import { formatCurrency } from 'src/util/formatCurrency';
 import type { DonationConfig } from '@v1/donations/checkout/DonationConfig';
@@ -24,12 +25,14 @@ HTMLFormElement,
     onSuccess: () => void;
     returnUrl: string;
     onLoadingChange?: (loading: boolean) => void;
+    onEmailChange: (email: string) => void;
 }
 >(({
             donation,
             onSuccess,
             returnUrl,
             onLoadingChange,
+            onEmailChange,
         }, ref) => {
             const stripe = useStripe();
             const elements = useElements();
@@ -75,6 +78,12 @@ HTMLFormElement,
                     clientSecret,
                     confirmParams: {
                         return_url: returnUrl,
+                        receipt_email: donation.email,
+                        payment_method_data: {
+                            billing_details: {
+                                email: donation.email,
+                            },
+                        },
                     },
                     redirect: 'if_required',
                 });
@@ -149,6 +158,17 @@ HTMLFormElement,
                             </div>
                         </div>
                     </div>
+
+                    <Input
+                        label="Email"
+                        type="email"
+                        placeholder="you@example.com"
+                        value={donation.email}
+                        required
+                        onChange={(e) => {
+                            onEmailChange(e.target.value);
+                        }}
+                    />
 
                     <div style={{ display: expressCheckoutAvailable ? undefined : 'none' }}>
                         <ExpressCheckoutElement

--- a/src/app/(frontend)/[pageID]/CheckoutForm.tsx
+++ b/src/app/(frontend)/[pageID]/CheckoutForm.tsx
@@ -35,6 +35,7 @@ HTMLFormElement,
             const elements = useElements();
             const [error, setError] = useState<string | null>(null);
             const [loading, setLoading] = useState(false);
+            const [expressCheckoutAvailable, setExpressCheckoutAvailable] = useState(false);
 
             const estFee = estimateFee(donation.amount);
             const feeAmount = donation.coverFees ? estFee : 0;
@@ -149,32 +150,41 @@ HTMLFormElement,
                         </div>
                     </div>
 
-                    <ExpressCheckoutElement
-                        onConfirm={handleExpressConfirm}
-                        options={{
-                            buttonType: {
-                                applePay: 'donate',
-                                googlePay: 'donate',
-                            },
-                        }}
-                    />
-
-                    <div className="flex items-center gap-3">
-                        <div
-                            className="flex-1 h-px"
-                            style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
-                        />
-                        <Text
-                            kind="paragraphXSmall"
-                            style={{ color: 'var(--pte-colors-contentTertiary, #6b7280)' }}
-                        >
-                            Or pay with card
-                        </Text>
-                        <div
-                            className="flex-1 h-px"
-                            style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                    <div style={{ display: expressCheckoutAvailable ? undefined : 'none' }}>
+                        <ExpressCheckoutElement
+                            onConfirm={handleExpressConfirm}
+                            onReady={({ availablePaymentMethods }) => {
+                                if (availablePaymentMethods) {
+                                    setExpressCheckoutAvailable(true);
+                                }
+                            }}
+                            options={{
+                                buttonType: {
+                                    applePay: 'donate',
+                                    googlePay: 'donate',
+                                },
+                            }}
                         />
                     </div>
+
+                    {expressCheckoutAvailable && (
+                        <div className="flex items-center gap-3">
+                            <div
+                                className="flex-1 h-px"
+                                style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                            />
+                            <Text
+                                kind="paragraphXSmall"
+                                style={{ color: 'var(--pte-colors-contentTertiary, #6b7280)' }}
+                            >
+                                Or pay with card
+                            </Text>
+                            <div
+                                className="flex-1 h-px"
+                                style={{ background: 'var(--pte-colors-borderOpaque, #e5e5e5)' }}
+                            />
+                        </div>
+                    )}
 
                     <PaymentElement options={{ layout: 'accordion' }} />
 

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -53,6 +53,7 @@ const initialDonation: DonationConfig = {
     projectName: HappinessConfig.name,
     pageID: '',
     tipPercent: 0.1,
+    email: '',
 };
 
 /** Compute the total amount in cents for a given donation config */
@@ -134,7 +135,7 @@ export const DonateButton = ({
                 onClick={() => {
                     checkoutFormRef.current?.requestSubmit();
                 }}
-                disabled={paymentLoading}
+                disabled={paymentLoading || !donation.email}
                 style={{ width: '100%' }}
             >
                 {paymentLoading
@@ -448,6 +449,7 @@ const DonateDrawerInner = ({
                         onSuccess={onSuccess}
                         returnUrl={returnUrl}
                         onLoadingChange={setPaymentLoading}
+                        onEmailChange={(email) => setDonation((d) => ({ ...d, email }))}
                     />
                 </div>
             )}

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -39,6 +39,8 @@ const STRIPE_APPEARANCE = {
         borderRadius: '8px',
         fontFamily: "'Graphik Web', -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Oxygen, Ubuntu, Cantarell, \"Open Sans\", \"Helvetica Neue\", sans-serif",
         colorPrimary: '#131313',
+        fontSizeBase: '14px',
+        spacingUnit: '3px',
     },
 };
 

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -112,7 +112,11 @@ export const DonateButton = ({
             >
                 Donate
             </Button>
-            {drawerOpen && (
+            <Drawer
+                title={view === 'payment' ? 'Payment' : 'Donate'}
+                isOpen={drawerOpen}
+                onClose={() => handleClose()}
+            >
                 <Elements
                     key={`${elementsMode}-${donation.frequency}`}
                     stripe={stripePromise}
@@ -130,8 +134,6 @@ export const DonateButton = ({
                 >
                     {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
                     <DonateDrawerContent
-                        drawerOpen={drawerOpen}
-                        onClose={handleClose}
                         donation={donation}
                         setDonation={setDonation}
                         showOtherAmount={showOtherAmount}
@@ -144,7 +146,7 @@ export const DonateButton = ({
                         onSuccess={handleSuccess}
                     />
                 </Elements>
-            )}
+            </Drawer>
         </>
     );
 };
@@ -154,8 +156,6 @@ export const DonateButton = ({
  * Needed because useStripe/useElements can only be called within the Elements provider.
  */
 const DonateDrawerContent = ({
-    drawerOpen,
-    onClose,
     donation,
     setDonation,
     showOtherAmount,
@@ -167,8 +167,6 @@ const DonateDrawerContent = ({
     total,
     onSuccess,
 }: {
-    drawerOpen: boolean;
-    onClose: () => void;
     donation: DonationConfig;
     setDonation: React.Dispatch<React.SetStateAction<DonationConfig>>;
     showOtherAmount: boolean;
@@ -271,11 +269,7 @@ const DonateDrawerContent = ({
     }, []);
 
     return (
-        <Drawer
-            title={view === 'payment' ? 'Payment' : 'Donate'}
-            isOpen={drawerOpen}
-            onClose={onClose}
-        >
+        <>
             {view === 'details' && (
                 <div className="w-full flex flex-col gap-6">
                     <ButtonGroup
@@ -538,6 +532,6 @@ const DonateDrawerContent = ({
                     />
                 </div>
             )}
-        </Drawer>
+        </>
     );
 };

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -1,9 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import { Elements, ExpressCheckoutElement, useStripe, useElements } from '@stripe/react-stripe-js';
-import type { StripeExpressCheckoutElementConfirmEvent, StripeExpressCheckoutElementReadyEvent } from '@stripe/stripe-js';
+import {
+    useCallback, useEffect, useMemo, useState,
+} from 'react';
+import {
+    useSearchParams, useRouter,
+} from 'next/navigation';
+import {
+    Elements, ExpressCheckoutElement, useStripe, useElements,
+} from '@stripe/react-stripe-js';
+import type {
+    StripeExpressCheckoutElementConfirmEvent,
+    StripeExpressCheckoutElementReadyEvent,
+} from '@stripe/stripe-js';
 import { Button } from 'paris/button';
 import { Drawer } from 'paris/drawer';
 import { Text } from 'paris/text';
@@ -122,6 +131,7 @@ export const DonateButton = ({
                         },
                     }}
                 >
+                    {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
                     <DonateDrawerContent
                         drawerOpen={drawerOpen}
                         onClose={handleClose}
@@ -497,7 +507,14 @@ const DonateDrawerContent = ({
 
                 {/* Hidden Express Checkout to detect availability */}
                 {!expressCheckoutReady && (
-                    <div style={{ position: 'absolute', opacity: 0, pointerEvents: 'none', height: 0, overflow: 'hidden' }}>
+                    <div style={{
+                        position: 'absolute',
+                        opacity: 0,
+                        pointerEvents: 'none',
+                        height: 0,
+                        overflow: 'hidden',
+                    }}
+                    >
                         <ExpressCheckoutElement
                             onReady={handleExpressCheckoutReady}
                             onConfirm={handleExpressCheckoutConfirm}

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -27,14 +27,13 @@ import { HappinessConfig } from 'happiness.config';
 import { DonationAmountSelector } from 'src/components/DonationAmountSelector';
 import { stripePromise } from '@lib/stripe/client';
 import { CheckoutForm } from '@frontend/[pageID]/CheckoutForm';
-import { usePagination } from 'paris/pagination';
 
 import clsx from 'clsx';
 import styles from 'src/app/(frontend)/[pageID]/DonateButton.module.scss';
 
 export const AmountPresets = [1000, 2500, 5000, 10000, 25000] as number[];
 
-const DrawerPages = ['details', 'payment'] as const;
+type DrawerView = 'details' | 'payment';
 
 const initialDonation: DonationConfig = {
     amount: 1000,
@@ -75,8 +74,7 @@ export const DonateButton = ({
 
     const [showOtherAmount, setShowOtherAmount] = useState(false);
     const [otherAmountInput, setOtherAmountInput] = useState('');
-
-    const pagination = usePagination<typeof DrawerPages>('details');
+    const [view, setView] = useState<DrawerView>('details');
 
     const total = useMemo(() => computeTotal(donation), [donation]);
 
@@ -97,13 +95,12 @@ export const DonateButton = ({
         });
         setShowOtherAmount(false);
         setOtherAmountInput('');
-        pagination.reset();
-    }, [projectName, pageID, pagination]);
+        setView('details');
+    }, [projectName, pageID]);
 
     const handleSuccess = useCallback(() => {
         const name = donation.anonymous ? 'Anonymous' : 'Donor';
         handleClose();
-        // Trigger ThanksDialog via URL param using router for SPA navigation
         router.replace(`/${pageID}?thanks=${encodeURIComponent(name)}`);
     }, [handleClose, donation.anonymous, pageID, router]);
 
@@ -121,7 +118,7 @@ export const DonateButton = ({
                     stripe={stripePromise}
                     options={{
                         mode: elementsMode,
-                        amount: Math.max(total, 50), // Stripe minimum is $0.50
+                        amount: Math.max(total, 50),
                         currency: 'usd',
                         appearance: {
                             theme: 'stripe',
@@ -141,11 +138,10 @@ export const DonateButton = ({
                         setShowOtherAmount={setShowOtherAmount}
                         otherAmountInput={otherAmountInput}
                         setOtherAmountInput={setOtherAmountInput}
-                        pagination={pagination}
+                        view={view}
+                        setView={setView}
                         total={total}
                         onSuccess={handleSuccess}
-                        pageID={pageID}
-                        projectName={projectName}
                     />
                 </Elements>
             )}
@@ -155,7 +151,7 @@ export const DonateButton = ({
 
 /**
  * Inner component that renders inside <Elements>.
- * This is needed because useStripe/useElements can only be called within the Elements provider.
+ * Needed because useStripe/useElements can only be called within the Elements provider.
  */
 const DonateDrawerContent = ({
     drawerOpen,
@@ -166,11 +162,10 @@ const DonateDrawerContent = ({
     setShowOtherAmount,
     otherAmountInput,
     setOtherAmountInput,
-    pagination,
+    view,
+    setView,
     total,
     onSuccess,
-    pageID,
-    projectName,
 }: {
     drawerOpen: boolean;
     onClose: () => void;
@@ -180,11 +175,10 @@ const DonateDrawerContent = ({
     setShowOtherAmount: (v: boolean) => void;
     otherAmountInput: string;
     setOtherAmountInput: (v: string) => void;
-    pagination: ReturnType<typeof usePagination<typeof DrawerPages>>;
+    view: DrawerView;
+    setView: (v: DrawerView) => void;
     total: number;
     onSuccess: () => void;
-    pageID?: string;
-    projectName?: string;
 }) => {
     const stripe = useStripe();
     const elements = useElements();
@@ -205,20 +199,21 @@ const DonateDrawerContent = ({
         }
     }, [elements, total]);
 
-    const returnUrl = typeof window !== 'undefined'
-        ? `${window.location.origin}/v1/donations/checkout/success`
-        : '';
+    const returnUrl = useMemo(
+        () => (typeof window !== 'undefined'
+            ? `${window.location.origin}/v1/donations/checkout/success`
+            : ''),
+        [],
+    );
 
     const createIntentAndConfirm = useCallback(async () => {
         if (!stripe || !elements) return;
 
-        // Submit to validate
         const { error: submitError } = await elements.submit();
         if (submitError) {
             throw new Error(submitError.message ?? 'Validation failed');
         }
 
-        // Create intent on server
         const res = await fetch('/v1/donations/create-intent', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -235,7 +230,6 @@ const DonateDrawerContent = ({
 
         const { clientSecret } = await res.json();
 
-        // Confirm payment
         const { error: confirmError } = await stripe.confirmPayment({
             elements,
             clientSecret,
@@ -249,7 +243,6 @@ const DonateDrawerContent = ({
             throw new Error(confirmError.message ?? 'Payment failed');
         }
 
-        // Success
         onSuccess();
     }, [stripe, elements, donation, feeAmount, returnUrl, onSuccess]);
 
@@ -261,7 +254,6 @@ const DonateDrawerContent = ({
         try {
             await createIntentAndConfirm();
         } catch (e) {
-            // Dismiss the payment sheet with an error
             event.paymentFailed({ reason: 'fail' });
             setExpressError(e instanceof Error ? e.message : 'Payment failed');
         } finally {
@@ -280,264 +272,272 @@ const DonateDrawerContent = ({
 
     return (
         <Drawer
-            title="Donate"
+            title={view === 'payment' ? 'Payment' : 'Donate'}
             isOpen={drawerOpen}
             onClose={onClose}
-            pagination={pagination}
         >
-            {/* Page 1: Donation Details + Express Checkout */}
-            <div key="details" className="w-full flex flex-col gap-6">
-                <ButtonGroup
-                    options={FrequencyOptions.map((f) => ({ id: f, name: f }))}
-                    selected={donation.frequency}
-                    onChange={({ id }) => {
-                        setDonation((d) => ({
-                            ...d,
-                            frequency: id as DonationConfig['frequency'],
-                        }));
-                    }}
-                />
-                <div className="flex flex-col gap-2">
-                    <div className="grid grid-cols-3 gap-2">
-                        {AmountPresets.map((amount) => (
+            {view === 'details' && (
+                <div className="w-full flex flex-col gap-6">
+                    <ButtonGroup
+                        options={FrequencyOptions.map((f) => ({ id: f, name: f }))}
+                        selected={donation.frequency}
+                        onChange={({ id }) => {
+                            setDonation((d) => ({
+                                ...d,
+                                frequency: id as DonationConfig['frequency'],
+                            }));
+                        }}
+                    />
+                    <div className="flex flex-col gap-2">
+                        <div className="grid grid-cols-3 gap-2">
+                            {AmountPresets.map((amount) => (
+                                <DonationAmountSelector
+                                    selected={donation.amount === amount}
+                                    key={amount}
+                                    onClick={() => {
+                                        setDonation((d) => ({
+                                            ...d,
+                                            amount,
+                                        }));
+                                        setShowOtherAmount(false);
+                                    }}
+                                >
+                                    <Text
+                                        kind="paragraphSmall"
+                                        style={{ fontWeight: 500 }}
+                                    >
+                                        {formatCurrency(amount, 0)}
+                                    </Text>
+                                </DonationAmountSelector>
+                            ))}
                             <DonationAmountSelector
-                                selected={donation.amount === amount}
-                                key={amount}
+                                selected={!AmountPresets.includes(donation.amount)}
+                                key="otherAmount"
                                 onClick={() => {
                                     setDonation((d) => ({
                                         ...d,
-                                        amount,
+                                        amount: 0,
                                     }));
-                                    setShowOtherAmount(false);
+                                    setOtherAmountInput('');
+                                    setShowOtherAmount(true);
                                 }}
                             >
                                 <Text
                                     kind="paragraphSmall"
                                     style={{ fontWeight: 500 }}
                                 >
-                                    {formatCurrency(amount, 0)}
+                                    Other
                                 </Text>
                             </DonationAmountSelector>
-                        ))}
-                        <DonationAmountSelector
-                            selected={!AmountPresets.includes(donation.amount)}
-                            key="otherAmount"
-                            onClick={() => {
-                                setDonation((d) => ({
-                                    ...d,
-                                    amount: 0,
-                                }));
-                                setOtherAmountInput('');
-                                setShowOtherAmount(true);
+                        </div>
+                        <div
+                            className="overflow-clip"
+                            style={{
+                                transition: 'all 0.2s ease-in-out',
+                                maxHeight: showOtherAmount ? '40px' : 0,
+                                marginBottom: showOtherAmount ? '0px' : '-8px',
                             }}
                         >
-                            <Text
-                                kind="paragraphSmall"
-                                style={{ fontWeight: 500 }}
-                            >
-                                Other
-                            </Text>
-                        </DonationAmountSelector>
+                            <Input
+                                label="Other amount"
+                                hideLabel
+                                placeholder="Enter amount"
+                                type="text"
+                                value={otherAmountInput}
+                                startEnhancer="$"
+                                onChange={(e) => {
+                                    const { value } = e.target;
+                                    if (/^[0-9]+(\.[0-9]{0,2}|)$/.test(value) || value === '') {
+                                        setOtherAmountInput(value);
+                                        setDonation((d) => ({
+                                            ...d,
+                                            amount: Number(value) * 100,
+                                        }));
+                                    }
+                                }}
+                            />
+                        </div>
                     </div>
-                    <div
-                        className="overflow-clip"
-                        style={{
-                            transition: 'all 0.2s ease-in-out',
-                            maxHeight: showOtherAmount ? '40px' : 0,
-                            marginBottom: showOtherAmount ? '0px' : '-8px',
+                    <TextArea
+                        label={(
+                            <div>
+                                <Text
+                                    kind="paragraphSmall"
+                                    style={{ fontWeight: 500 }}
+                                >
+                                    Message
+                                </Text>
+                                {' '}
+                                <Text kind="paragraphSmall">
+                                    (optional)
+                                </Text>
+                            </div>
+                        )}
+                        placeholder="Keep up the good work!"
+                        value={donation.message}
+                        style={{ minHeight: '80px' }}
+                        onChange={(e) => {
+                            const { value } = e.target;
+                            setDonation((d) => ({
+                                ...d,
+                                message: value,
+                            }));
                         }}
-                    >
-                        <Input
-                            label="Other amount"
-                            hideLabel
-                            placeholder="Enter amount"
-                            type="text"
-                            value={otherAmountInput}
-                            startEnhancer="$"
+                    />
+                    <div className={clsx(styles.TempCheckboxSpacing)}>
+                        <Checkbox
+                            checked={donation.coverFees}
                             onChange={(e) => {
-                                const { value } = e.target;
-                                if (/^[0-9]+(\.[0-9]{0,2}|)$/.test(value) || value === '') {
-                                    setOtherAmountInput(value);
-                                    setDonation((d) => ({
-                                        ...d,
-                                        amount: Number(value) * 100,
-                                    }));
-                                }
+                                setDonation((d) => ({
+                                    ...d,
+                                    coverFees: Boolean(e),
+                                }));
                             }}
-                        />
+                        >
+                            <Text kind="paragraphXSmall">
+                                Add
+                                {' '}
+                                <strong>
+                                    {formatCurrency(estFee, 2)}
+                                </strong>
+                                {' '}
+                                to cover processing fees
+                            </Text>
+                        </Checkbox>
                     </div>
-                </div>
-                <TextArea
-                    label={(
-                        <div>
-                            <Text
-                                kind="paragraphSmall"
-                                style={{ fontWeight: 500 }}
-                            >
-                                Message
+                    <div className={clsx(styles.TempCheckboxSpacing)}>
+                        <Checkbox
+                            checked={donation.anonymous}
+                            onChange={(e) => {
+                                setDonation((d) => ({
+                                    ...d,
+                                    anonymous: Boolean(e),
+                                }));
+                            }}
+                        >
+                            <Text kind="paragraphXSmall">
+                                Make my donation anonymous
                             </Text>
-                            {' '}
-                            <Text kind="paragraphSmall">
-                                (optional)
+                        </Checkbox>
+                    </div>
+                    <div className={clsx(styles.TempCheckboxSpacing)}>
+                        <Checkbox
+                            checked={donation.tipPercent !== 0}
+                            onChange={(e) => {
+                                setDonation((d) => ({
+                                    ...d,
+                                    tipPercent: e ? 0.05 : 0,
+                                }));
+                            }}
+                        >
+                            <Text kind="paragraphXSmall">
+                                Add a tip for
+                                {' '}
+                                {HappinessConfig.name}
                             </Text>
+                        </Checkbox>
+                        {donation.tipPercent !== 0 ? (
+                            <div className="flex flex-col mt-4 gap-4">
+                                <Text kind="paragraphXSmall">
+                                    {HappinessConfig.tipDescription}
+                                </Text>
+                                <div className="grid grid-cols-3 gap-2">
+                                    {[0.05, 0.1, 0.2].map((pct) => (
+                                        <DonationAmountSelector
+                                            key={`tip-${pct}`}
+                                            size="small"
+                                            selected={donation.tipPercent === pct}
+                                            onClick={() => {
+                                                setDonation((d) => ({
+                                                    ...d,
+                                                    tipPercent: pct,
+                                                }));
+                                            }}
+                                        >
+                                            <Text
+                                                kind="paragraphXSmall"
+                                                style={{ fontWeight: 500 }}
+                                            >
+                                                {pct * 100}
+                                                %
+                                            </Text>
+                                        </DonationAmountSelector>
+                                    ))}
+                                </div>
+                            </div>
+                        ) : null}
+                    </div>
+
+                    {/* Express Checkout (Apple Pay, Google Pay, Link) */}
+                    {expressCheckoutReady && donation.amount > 0 && (
+                        <div className="flex flex-col gap-2">
+                            <div className="flex items-center gap-3">
+                                <div className="flex-1 h-px bg-gray-200" />
+                                <Text kind="paragraphXSmall" style={{ color: '#6b7280' }}>
+                                    Express checkout
+                                </Text>
+                                <div className="flex-1 h-px bg-gray-200" />
+                            </div>
+                            <ExpressCheckoutElement
+                                onConfirm={handleExpressCheckoutConfirm}
+                                onReady={handleExpressCheckoutReady}
+                                options={{
+                                    buttonType: {
+                                        applePay: 'donate',
+                                        googlePay: 'donate',
+                                    },
+                                }}
+                            />
+                            {expressError && (
+                                <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
+                                    {expressError}
+                                </Text>
+                            )}
                         </div>
                     )}
-                    placeholder="Keep up the good work!"
-                    value={donation.message}
-                    style={{ minHeight: '80px' }}
-                    onChange={(e) => {
-                        const { value } = e.target;
-                        setDonation((d) => ({
-                            ...d,
-                            message: value,
-                        }));
-                    }}
-                />
-                <div className={clsx(styles.TempCheckboxSpacing)}>
-                    <Checkbox
-                        checked={donation.coverFees}
-                        onChange={(e) => {
-                            setDonation((d) => ({
-                                ...d,
-                                coverFees: Boolean(e),
-                            }));
+
+                    {/* Hidden Express Checkout to detect availability */}
+                    {!expressCheckoutReady && (
+                        <div style={{
+                            position: 'absolute',
+                            opacity: 0,
+                            pointerEvents: 'none',
+                            height: 0,
+                            overflow: 'hidden',
                         }}
-                    >
-                        <Text kind="paragraphXSmall">
-                            Add
-                            {' '}
-                            <strong>
-                                {formatCurrency(estFee, 2)}
-                            </strong>
-                            {' '}
-                            to cover processing fees
-                        </Text>
-                    </Checkbox>
-                </div>
-                <div className={clsx(styles.TempCheckboxSpacing)}>
-                    <Checkbox
-                        checked={donation.anonymous}
-                        onChange={(e) => {
-                            setDonation((d) => ({
-                                ...d,
-                                anonymous: Boolean(e),
-                            }));
-                        }}
-                    >
-                        <Text kind="paragraphXSmall">
-                            Make my donation anonymous
-                        </Text>
-                    </Checkbox>
-                </div>
-                <div className={clsx(styles.TempCheckboxSpacing)}>
-                    <Checkbox
-                        checked={donation.tipPercent !== 0}
-                        onChange={(e) => {
-                            setDonation((d) => ({
-                                ...d,
-                                tipPercent: e ? 0.05 : 0,
-                            }));
-                        }}
-                    >
-                        <Text kind="paragraphXSmall">
-                            Add a tip for
-                            {' '}
-                            {HappinessConfig.name}
-                        </Text>
-                    </Checkbox>
-                    {donation.tipPercent !== 0 ? (
-                        <div className="flex flex-col mt-4 gap-4">
-                            <Text kind="paragraphXSmall">
-                                {HappinessConfig.tipDescription}
-                            </Text>
-                            <div className="grid grid-cols-3 gap-2">
-                                {[0.05, 0.1, 0.2].map((pct) => (
-                                    <DonationAmountSelector
-                                        key={`tip-${pct}`}
-                                        size="small"
-                                        selected={donation.tipPercent === pct}
-                                        onClick={() => {
-                                            setDonation((d) => ({
-                                                ...d,
-                                                tipPercent: pct,
-                                            }));
-                                        }}
-                                    >
-                                        <Text
-                                            kind="paragraphXSmall"
-                                            style={{ fontWeight: 500 }}
-                                        >
-                                            {pct * 100}
-                                            %
-                                        </Text>
-                                    </DonationAmountSelector>
-                                ))}
-                            </div>
+                        >
+                            <ExpressCheckoutElement
+                                onReady={handleExpressCheckoutReady}
+                                onConfirm={handleExpressCheckoutConfirm}
+                            />
                         </div>
-                    ) : null}
-                </div>
+                    )}
 
-                {/* Express Checkout (Apple Pay, Google Pay, Link) */}
-                {expressCheckoutReady && donation.amount > 0 && (
-                    <div className="flex flex-col gap-2">
-                        <div className="flex items-center gap-3">
-                            <div className="flex-1 h-px bg-gray-200" />
-                            <Text kind="paragraphXSmall" style={{ color: '#6b7280' }}>
-                                Express checkout
-                            </Text>
-                            <div className="flex-1 h-px bg-gray-200" />
-                        </div>
-                        <ExpressCheckoutElement
-                            onConfirm={handleExpressCheckoutConfirm}
-                            onReady={handleExpressCheckoutReady}
-                            options={{
-                                buttonType: {
-                                    applePay: 'donate',
-                                    googlePay: 'donate',
-                                },
-                            }}
-                        />
-                        {expressError && (
-                            <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
-                                {expressError}
-                            </Text>
-                        )}
-                    </div>
-                )}
-
-                {/* Hidden Express Checkout to detect availability */}
-                {!expressCheckoutReady && (
-                    <div style={{
-                        position: 'absolute',
-                        opacity: 0,
-                        pointerEvents: 'none',
-                        height: 0,
-                        overflow: 'hidden',
-                    }}
+                    <Button
+                        onClick={() => setView('payment')}
+                        disabled={donation.amount === 0 || expressLoading}
                     >
-                        <ExpressCheckoutElement
-                            onReady={handleExpressCheckoutReady}
-                            onConfirm={handleExpressCheckoutConfirm}
-                        />
-                    </div>
-                )}
+                        {`Continue to Payment \u2014 ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
+                    </Button>
+                </div>
+            )}
 
-                <Button
-                    onClick={() => pagination.open('payment')}
-                    disabled={donation.amount === 0 || expressLoading}
-                >
-                    {`Continue to Payment \u2014 ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
-                </Button>
-            </div>
-
-            {/* Page 2: Payment Element */}
-            <div key="payment" className="w-full">
-                <CheckoutForm
-                    donation={donation}
-                    onSuccess={onSuccess}
-                    returnUrl={returnUrl}
-                />
-            </div>
+            {view === 'payment' && (
+                <div className="w-full flex flex-col gap-4">
+                    <Button
+                        kind="tertiary"
+                        size="small"
+                        onClick={() => setView('details')}
+                    >
+                        &larr; Back to details
+                    </Button>
+                    <CheckoutForm
+                        donation={donation}
+                        onSuccess={onSuccess}
+                        returnUrl={returnUrl}
+                    />
+                </div>
+            )}
         </Drawer>
     );
 };

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Elements, ExpressCheckoutElement, useStripe, useElements } from '@stripe/react-stripe-js';
+import type { StripeExpressCheckoutElementConfirmEvent, StripeExpressCheckoutElementReadyEvent } from '@stripe/stripe-js';
 import { Button } from 'paris/button';
 import { Drawer } from 'paris/drawer';
 import { Text } from 'paris/text';
@@ -14,11 +16,16 @@ import type { DonationConfig } from '@v1/donations/checkout/DonationConfig';
 import { estimateFee, FrequencyOptions } from '@v1/donations/checkout/DonationConfig';
 import { HappinessConfig } from 'happiness.config';
 import { DonationAmountSelector } from 'src/components/DonationAmountSelector';
+import { stripePromise } from '@lib/stripe/client';
+import { CheckoutForm } from '@frontend/[pageID]/CheckoutForm';
+import { usePagination } from 'paris/pagination';
 
 import clsx from 'clsx';
 import styles from 'src/app/(frontend)/[pageID]/DonateButton.module.scss';
 
 export const AmountPresets = [1000, 2500, 5000, 10000, 25000] as number[];
+
+const DrawerPages = ['details', 'payment'] as const;
 
 const initialDonation: DonationConfig = {
     amount: 1000,
@@ -31,48 +38,65 @@ const initialDonation: DonationConfig = {
     tipPercent: 0.1,
 };
 
+/** Compute the total amount in cents for a given donation config */
+const computeTotal = (donation: DonationConfig) => {
+    const fee = donation.coverFees ? estimateFee(donation.amount) : 0;
+    const tip = Math.round((donation.amount + fee) * donation.tipPercent);
+    return donation.amount + fee + tip;
+};
+
 export const DonateButton = ({
     projectName,
     pageID,
     className = '',
 }: {
-    projectName?: string,
-    pageID?: string,
-    className?: string,
+    projectName?: string;
+    pageID?: string;
+    className?: string;
 }) => {
     const params = useSearchParams();
+    const router = useRouter();
     const [drawerOpen, setDrawerOpen] = useState(false);
 
     const [donation, setDonation] = useState<DonationConfig>({
         ...initialDonation,
         projectName: projectName || HappinessConfig.name,
+        pageID: pageID || '',
     });
 
     const [showOtherAmount, setShowOtherAmount] = useState(false);
-    const [otherAmountInput, setOtherAmountInput] = useState('' as string);
+    const [otherAmountInput, setOtherAmountInput] = useState('');
 
-    const estFee = useMemo(() => (
-        estimateFee(donation.amount)
-    ), [donation.amount]);
+    const pagination = usePagination<typeof DrawerPages>('details');
 
-    const checkoutURL = useMemo(() => (
-        `/v1/donations/checkout?${new URLSearchParams(
-            Object.fromEntries(
-                Object.entries({
-                    ...donation,
-                    amount: donation.amount + (donation.coverFees ? estFee : 0),
-                    pageName: projectName || HappinessConfig.name,
-                    pageID,
-                }).map(([key, value]) => [key, String(value)]),
-            ),
-        ).toString()}`
-    ), [donation, estFee, pageID, projectName]);
+    const total = useMemo(() => computeTotal(donation), [donation]);
+
+    const elementsMode = donation.frequency === 'Monthly' ? 'subscription' : 'payment';
 
     useEffect(() => {
         if (params.get('open') === 'donate') {
             setDrawerOpen(true);
         }
     }, [params]);
+
+    const handleClose = useCallback(() => {
+        setDrawerOpen(false);
+        setDonation({
+            ...initialDonation,
+            projectName: projectName || HappinessConfig.name,
+            pageID: pageID || '',
+        });
+        setShowOtherAmount(false);
+        setOtherAmountInput('');
+        pagination.reset();
+    }, [projectName, pageID, pagination]);
+
+    const handleSuccess = useCallback(() => {
+        const name = donation.anonymous ? 'Anonymous' : 'Donor';
+        handleClose();
+        // Trigger ThanksDialog via URL param using router for SPA navigation
+        router.replace(`/${pageID}?thanks=${encodeURIComponent(name)}`);
+    }, [handleClose, donation.anonymous, pageID, router]);
 
     return (
         <>
@@ -82,239 +106,421 @@ export const DonateButton = ({
             >
                 Donate
             </Button>
-            <Drawer
-                title="Donate"
-                isOpen={drawerOpen}
-                onClose={() => {
-                    setDrawerOpen(false);
-                    setDonation(initialDonation);
-                    setShowOtherAmount(false);
-                }}
-            >
-                <div className="w-full flex flex-col gap-6">
-                    <ButtonGroup
-                        options={FrequencyOptions.map((f) => ({ id: f, name: f }))}
-                        selected={donation.frequency}
-                        onChange={({ id }) => {
-                            setDonation((d) => ({
-                                ...d,
-                                frequency: id as DonationConfig['frequency'],
-                            }));
-                        }}
+            {drawerOpen && (
+                <Elements
+                    key={`${elementsMode}-${donation.frequency}`}
+                    stripe={stripePromise}
+                    options={{
+                        mode: elementsMode,
+                        amount: Math.max(total, 50), // Stripe minimum is $0.50
+                        currency: 'usd',
+                        appearance: {
+                            theme: 'stripe',
+                            variables: {
+                                borderRadius: '8px',
+                            },
+                        },
+                    }}
+                >
+                    <DonateDrawerContent
+                        drawerOpen={drawerOpen}
+                        onClose={handleClose}
+                        donation={donation}
+                        setDonation={setDonation}
+                        showOtherAmount={showOtherAmount}
+                        setShowOtherAmount={setShowOtherAmount}
+                        otherAmountInput={otherAmountInput}
+                        setOtherAmountInput={setOtherAmountInput}
+                        pagination={pagination}
+                        total={total}
+                        onSuccess={handleSuccess}
+                        pageID={pageID}
+                        projectName={projectName}
                     />
-                    <div className="flex flex-col gap-2">
-                        <div className="grid grid-cols-3 gap-2">
-                            {AmountPresets.map((amount) => (
-                                <DonationAmountSelector
-                                    selected={donation.amount === amount}
-                                    key={amount}
-                                    onClick={() => {
-                                        setDonation((d) => ({
-                                            ...d,
-                                            amount,
-                                        }));
-                                        setShowOtherAmount(false);
-                                    }}
-                                >
-                                    <Text
-                                        kind="paragraphSmall"
-                                        style={{
-                                            fontWeight: 500,
-                                        }}
-                                    >
-                                        {formatCurrency(amount, 0)}
-                                    </Text>
-                                </DonationAmountSelector>
-                            ))}
+                </Elements>
+            )}
+        </>
+    );
+};
+
+/**
+ * Inner component that renders inside <Elements>.
+ * This is needed because useStripe/useElements can only be called within the Elements provider.
+ */
+const DonateDrawerContent = ({
+    drawerOpen,
+    onClose,
+    donation,
+    setDonation,
+    showOtherAmount,
+    setShowOtherAmount,
+    otherAmountInput,
+    setOtherAmountInput,
+    pagination,
+    total,
+    onSuccess,
+    pageID,
+    projectName,
+}: {
+    drawerOpen: boolean;
+    onClose: () => void;
+    donation: DonationConfig;
+    setDonation: React.Dispatch<React.SetStateAction<DonationConfig>>;
+    showOtherAmount: boolean;
+    setShowOtherAmount: (v: boolean) => void;
+    otherAmountInput: string;
+    setOtherAmountInput: (v: string) => void;
+    pagination: ReturnType<typeof usePagination<typeof DrawerPages>>;
+    total: number;
+    onSuccess: () => void;
+    pageID?: string;
+    projectName?: string;
+}) => {
+    const stripe = useStripe();
+    const elements = useElements();
+
+    const [expressCheckoutReady, setExpressCheckoutReady] = useState(false);
+    const [expressError, setExpressError] = useState<string | null>(null);
+    const [expressLoading, setExpressLoading] = useState(false);
+
+    const estFee = useMemo(() => estimateFee(donation.amount), [donation.amount]);
+    const feeAmount = donation.coverFees ? estFee : 0;
+
+    // Keep Elements amount in sync with donation total
+    useEffect(() => {
+        if (elements) {
+            elements.update({
+                amount: Math.max(total, 50),
+            });
+        }
+    }, [elements, total]);
+
+    const returnUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/v1/donations/checkout/success`
+        : '';
+
+    const createIntentAndConfirm = useCallback(async () => {
+        if (!stripe || !elements) return;
+
+        // Submit to validate
+        const { error: submitError } = await elements.submit();
+        if (submitError) {
+            throw new Error(submitError.message ?? 'Validation failed');
+        }
+
+        // Create intent on server
+        const res = await fetch('/v1/donations/create-intent', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                ...donation,
+                amount: donation.amount + feeAmount,
+            }),
+        });
+
+        if (!res.ok) {
+            const data = await res.json().catch(() => null);
+            throw new Error(data?.message ?? 'Failed to create payment');
+        }
+
+        const { clientSecret } = await res.json();
+
+        // Confirm payment
+        const { error: confirmError } = await stripe.confirmPayment({
+            elements,
+            clientSecret,
+            confirmParams: {
+                return_url: returnUrl,
+            },
+            redirect: 'if_required',
+        });
+
+        if (confirmError) {
+            throw new Error(confirmError.message ?? 'Payment failed');
+        }
+
+        // Success
+        onSuccess();
+    }, [stripe, elements, donation, feeAmount, returnUrl, onSuccess]);
+
+    const handleExpressCheckoutConfirm = useCallback(async (
+        event: StripeExpressCheckoutElementConfirmEvent,
+    ) => {
+        setExpressLoading(true);
+        setExpressError(null);
+        try {
+            await createIntentAndConfirm();
+        } catch (e) {
+            // Dismiss the payment sheet with an error
+            event.paymentFailed({ reason: 'fail' });
+            setExpressError(e instanceof Error ? e.message : 'Payment failed');
+        } finally {
+            setExpressLoading(false);
+        }
+    }, [createIntentAndConfirm]);
+
+    const handleExpressCheckoutReady = useCallback((
+        event: StripeExpressCheckoutElementReadyEvent,
+    ) => {
+        const methods = event.availablePaymentMethods;
+        setExpressCheckoutReady(
+            Boolean(methods && (methods.applePay || methods.googlePay || methods.link)),
+        );
+    }, []);
+
+    return (
+        <Drawer
+            title="Donate"
+            isOpen={drawerOpen}
+            onClose={onClose}
+            pagination={pagination}
+        >
+            {/* Page 1: Donation Details + Express Checkout */}
+            <div key="details" className="w-full flex flex-col gap-6">
+                <ButtonGroup
+                    options={FrequencyOptions.map((f) => ({ id: f, name: f }))}
+                    selected={donation.frequency}
+                    onChange={({ id }) => {
+                        setDonation((d) => ({
+                            ...d,
+                            frequency: id as DonationConfig['frequency'],
+                        }));
+                    }}
+                />
+                <div className="flex flex-col gap-2">
+                    <div className="grid grid-cols-3 gap-2">
+                        {AmountPresets.map((amount) => (
                             <DonationAmountSelector
-                                selected={!AmountPresets.includes(donation.amount)}
-                                key="otherAmount"
+                                selected={donation.amount === amount}
+                                key={amount}
                                 onClick={() => {
                                     setDonation((d) => ({
                                         ...d,
-                                        amount: 0,
+                                        amount,
                                     }));
-                                    setOtherAmountInput('');
-                                    setShowOtherAmount(true);
+                                    setShowOtherAmount(false);
                                 }}
                             >
                                 <Text
                                     kind="paragraphSmall"
-                                    style={{
-                                        fontWeight: 500,
-                                    }}
+                                    style={{ fontWeight: 500 }}
                                 >
-                                    Other
+                                    {formatCurrency(amount, 0)}
                                 </Text>
                             </DonationAmountSelector>
-                        </div>
-                        <div
-                            className="overflow-clip"
-                            style={{
-                                transition: 'all 0.2s ease-in-out',
-                                maxHeight: showOtherAmount ? '40px' : 0,
-                                marginBottom: showOtherAmount ? '0px' : '-8px',
-                            }}
-                        >
-                            <Input
-                                label="Other amount"
-                                hideLabel
-                                placeholder="Enter amount"
-                                type="text"
-                                value={otherAmountInput}
-                                startEnhancer="$"
-                                onChange={(e) => {
-                                    const { value } = e.target;
-                                    if (/^[0-9]+(\.[0-9]{0,2}|)$/.test(value) || value === '') {
-                                        setOtherAmountInput(value);
-                                        setDonation((d) => ({
-                                            ...d,
-                                            amount: Number(value) * 100,
-                                        }));
-                                    }
-                                }}
-                            />
-                        </div>
-                    </div>
-                    <TextArea
-                        label={(
-                            <div>
-                                <Text
-                                    kind="paragraphSmall"
-                                    style={{
-                                        fontWeight: 500,
-                                    }}
-                                >
-                                    Message
-                                </Text>
-                                {' '}
-                                <Text
-                                    kind="paragraphSmall"
-                                >
-                                    (optional)
-                                </Text>
-                            </div>
-                        )}
-                        placeholder="Keep up the good work!"
-                        value={donation.message}
-                        style={{ minHeight: '80px' }}
-                        onChange={(e) => {
-                            const { value } = e.target;
-                            setDonation((d) => ({
-                                ...d,
-                                message: value,
-                            }));
-                        }}
-                    />
-                    <div className={clsx(
-                        styles.TempCheckboxSpacing,
-                    )}
-                    >
-                        <Checkbox
-                            checked={donation.coverFees}
-                            onChange={(e) => {
+                        ))}
+                        <DonationAmountSelector
+                            selected={!AmountPresets.includes(donation.amount)}
+                            key="otherAmount"
+                            onClick={() => {
                                 setDonation((d) => ({
                                     ...d,
-                                    coverFees: Boolean(e),
+                                    amount: 0,
                                 }));
+                                setOtherAmountInput('');
+                                setShowOtherAmount(true);
                             }}
                         >
                             <Text
-                                kind="paragraphXSmall"
+                                kind="paragraphSmall"
+                                style={{ fontWeight: 500 }}
                             >
-                                Add
-                                {' '}
-                                <strong>
-                                    {formatCurrency(estFee, 2)}
-                                </strong>
-                                {' '}
-                                to cover processing fees
+                                Other
                             </Text>
-                        </Checkbox>
+                        </DonationAmountSelector>
                     </div>
-                    <div className={
-                        clsx(
-                            styles.TempCheckboxSpacing,
-                        )
-                    }
+                    <div
+                        className="overflow-clip"
+                        style={{
+                            transition: 'all 0.2s ease-in-out',
+                            maxHeight: showOtherAmount ? '40px' : 0,
+                            marginBottom: showOtherAmount ? '0px' : '-8px',
+                        }}
                     >
-                        <Checkbox
-                            checked={donation.anonymous}
+                        <Input
+                            label="Other amount"
+                            hideLabel
+                            placeholder="Enter amount"
+                            type="text"
+                            value={otherAmountInput}
+                            startEnhancer="$"
                             onChange={(e) => {
-                                setDonation((d) => ({
-                                    ...d,
-                                    anonymous: Boolean(e),
-                                }));
+                                const { value } = e.target;
+                                if (/^[0-9]+(\.[0-9]{0,2}|)$/.test(value) || value === '') {
+                                    setOtherAmountInput(value);
+                                    setDonation((d) => ({
+                                        ...d,
+                                        amount: Number(value) * 100,
+                                    }));
+                                }
                             }}
-                        >
-                            <Text kind="paragraphXSmall">
-                                Make my donation anonymous
-                            </Text>
-                        </Checkbox>
+                        />
                     </div>
-                    <div className={
-                        clsx(
-                            styles.TempCheckboxSpacing,
-                        )
-                    }
-                    >
-                        <Checkbox
-                            checked={donation.tipPercent !== 0}
-                            onChange={(e) => {
-                                setDonation((d) => ({
-                                    ...d,
-                                    tipPercent: e ? 0.05 : 0,
-                                }));
-                            }}
-                        >
-                            <Text kind="paragraphXSmall">
-                                Add a tip for
-                                {' '}
-                                {HappinessConfig.name}
-                            </Text>
-                        </Checkbox>
-                        {donation.tipPercent !== 0 ? (
-                            <div className="flex flex-col mt-4 gap-4">
-                                <Text kind="paragraphXSmall">
-                                    {HappinessConfig.tipDescription}
-                                </Text>
-                                <div className="grid grid-cols-3 gap-2">
-                                    {[0.05, 0.1, 0.2].map((pct) => (
-                                        <DonationAmountSelector
-                                            key={`tip-${pct}`}
-                                            size="small"
-                                            selected={donation.tipPercent === pct}
-                                            onClick={() => {
-                                                setDonation((d) => ({
-                                                    ...d,
-                                                    tipPercent: pct,
-                                                }));
-                                            }}
-                                        >
-                                            <Text
-                                                kind="paragraphXSmall"
-                                                style={{
-                                                    fontWeight: 500,
-                                                }}
-                                            >
-                                                {pct * 100}
-                                                %
-                                            </Text>
-                                        </DonationAmountSelector>
-                                    ))}
-                                </div>
-                            </div>
-                        ) : null}
-                    </div>
-                    <Button
-                        href={checkoutURL}
-                        hreftarget="_self"
-                        disabled={donation.amount === 0}
-                    >
-                        {`Donate ${formatCurrency(donation.amount + (donation.coverFees ? estFee : 0) + Math.round((donation.amount + (donation.coverFees ? estFee : 0)) * donation.tipPercent), 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
-                    </Button>
                 </div>
-            </Drawer>
-        </>
+                <TextArea
+                    label={(
+                        <div>
+                            <Text
+                                kind="paragraphSmall"
+                                style={{ fontWeight: 500 }}
+                            >
+                                Message
+                            </Text>
+                            {' '}
+                            <Text kind="paragraphSmall">
+                                (optional)
+                            </Text>
+                        </div>
+                    )}
+                    placeholder="Keep up the good work!"
+                    value={donation.message}
+                    style={{ minHeight: '80px' }}
+                    onChange={(e) => {
+                        const { value } = e.target;
+                        setDonation((d) => ({
+                            ...d,
+                            message: value,
+                        }));
+                    }}
+                />
+                <div className={clsx(styles.TempCheckboxSpacing)}>
+                    <Checkbox
+                        checked={donation.coverFees}
+                        onChange={(e) => {
+                            setDonation((d) => ({
+                                ...d,
+                                coverFees: Boolean(e),
+                            }));
+                        }}
+                    >
+                        <Text kind="paragraphXSmall">
+                            Add
+                            {' '}
+                            <strong>
+                                {formatCurrency(estFee, 2)}
+                            </strong>
+                            {' '}
+                            to cover processing fees
+                        </Text>
+                    </Checkbox>
+                </div>
+                <div className={clsx(styles.TempCheckboxSpacing)}>
+                    <Checkbox
+                        checked={donation.anonymous}
+                        onChange={(e) => {
+                            setDonation((d) => ({
+                                ...d,
+                                anonymous: Boolean(e),
+                            }));
+                        }}
+                    >
+                        <Text kind="paragraphXSmall">
+                            Make my donation anonymous
+                        </Text>
+                    </Checkbox>
+                </div>
+                <div className={clsx(styles.TempCheckboxSpacing)}>
+                    <Checkbox
+                        checked={donation.tipPercent !== 0}
+                        onChange={(e) => {
+                            setDonation((d) => ({
+                                ...d,
+                                tipPercent: e ? 0.05 : 0,
+                            }));
+                        }}
+                    >
+                        <Text kind="paragraphXSmall">
+                            Add a tip for
+                            {' '}
+                            {HappinessConfig.name}
+                        </Text>
+                    </Checkbox>
+                    {donation.tipPercent !== 0 ? (
+                        <div className="flex flex-col mt-4 gap-4">
+                            <Text kind="paragraphXSmall">
+                                {HappinessConfig.tipDescription}
+                            </Text>
+                            <div className="grid grid-cols-3 gap-2">
+                                {[0.05, 0.1, 0.2].map((pct) => (
+                                    <DonationAmountSelector
+                                        key={`tip-${pct}`}
+                                        size="small"
+                                        selected={donation.tipPercent === pct}
+                                        onClick={() => {
+                                            setDonation((d) => ({
+                                                ...d,
+                                                tipPercent: pct,
+                                            }));
+                                        }}
+                                    >
+                                        <Text
+                                            kind="paragraphXSmall"
+                                            style={{ fontWeight: 500 }}
+                                        >
+                                            {pct * 100}
+                                            %
+                                        </Text>
+                                    </DonationAmountSelector>
+                                ))}
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+
+                {/* Express Checkout (Apple Pay, Google Pay, Link) */}
+                {expressCheckoutReady && donation.amount > 0 && (
+                    <div className="flex flex-col gap-2">
+                        <div className="flex items-center gap-3">
+                            <div className="flex-1 h-px bg-gray-200" />
+                            <Text kind="paragraphXSmall" style={{ color: '#6b7280' }}>
+                                Express checkout
+                            </Text>
+                            <div className="flex-1 h-px bg-gray-200" />
+                        </div>
+                        <ExpressCheckoutElement
+                            onConfirm={handleExpressCheckoutConfirm}
+                            onReady={handleExpressCheckoutReady}
+                            options={{
+                                buttonType: {
+                                    applePay: 'donate',
+                                    googlePay: 'donate',
+                                },
+                            }}
+                        />
+                        {expressError && (
+                            <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
+                                {expressError}
+                            </Text>
+                        )}
+                    </div>
+                )}
+
+                {/* Hidden Express Checkout to detect availability */}
+                {!expressCheckoutReady && (
+                    <div style={{ position: 'absolute', opacity: 0, pointerEvents: 'none', height: 0, overflow: 'hidden' }}>
+                        <ExpressCheckoutElement
+                            onReady={handleExpressCheckoutReady}
+                            onConfirm={handleExpressCheckoutConfirm}
+                        />
+                    </div>
+                )}
+
+                <Button
+                    onClick={() => pagination.open('payment')}
+                    disabled={donation.amount === 0 || expressLoading}
+                >
+                    {`Continue to Payment \u2014 ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
+                </Button>
+            </div>
+
+            {/* Page 2: Payment Element */}
+            <div key="payment" className="w-full">
+                <CheckoutForm
+                    donation={donation}
+                    onSuccess={onSuccess}
+                    returnUrl={returnUrl}
+                />
+            </div>
+        </Drawer>
     );
 };

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -143,7 +143,7 @@ export const DonateButton = ({
                     : `Donate ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
             </Button>
         );
-    }, [pagination, donation.amount, donation.frequency, total, paymentLoading]);
+    }, [pagination, donation.amount, donation.frequency, donation.email, total, paymentLoading]);
 
     return (
         <>

--- a/src/app/(frontend)/[pageID]/DonateButton.tsx
+++ b/src/app/(frontend)/[pageID]/DonateButton.tsx
@@ -1,18 +1,14 @@
 'use client';
 
 import {
-    useCallback, useEffect, useMemo, useState,
+    useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
     useSearchParams, useRouter,
 } from 'next/navigation';
 import {
-    Elements, ExpressCheckoutElement, useStripe, useElements,
+    Elements, useStripe, useElements,
 } from '@stripe/react-stripe-js';
-import type {
-    StripeExpressCheckoutElementConfirmEvent,
-    StripeExpressCheckoutElementReadyEvent,
-} from '@stripe/stripe-js';
 import { Button } from 'paris/button';
 import { Drawer } from 'paris/drawer';
 import { Text } from 'paris/text';
@@ -27,13 +23,24 @@ import { HappinessConfig } from 'happiness.config';
 import { DonationAmountSelector } from 'src/components/DonationAmountSelector';
 import { stripePromise } from '@lib/stripe/client';
 import { CheckoutForm } from '@frontend/[pageID]/CheckoutForm';
+import { usePagination } from 'paris/pagination';
 
 import clsx from 'clsx';
 import styles from 'src/app/(frontend)/[pageID]/DonateButton.module.scss';
 
 export const AmountPresets = [1000, 2500, 5000, 10000, 25000] as number[];
 
-type DrawerView = 'details' | 'payment';
+const DrawerPages = ['details', 'payment'] as const;
+
+const STRIPE_APPEARANCE = {
+    theme: 'flat' as const,
+    labels: 'above' as const,
+    variables: {
+        borderRadius: '8px',
+        fontFamily: "'Graphik Web', -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Oxygen, Ubuntu, Cantarell, \"Open Sans\", \"Helvetica Neue\", sans-serif",
+        colorPrimary: '#131313',
+    },
+};
 
 const initialDonation: DonationConfig = {
     amount: 1000,
@@ -74,10 +81,12 @@ export const DonateButton = ({
 
     const [showOtherAmount, setShowOtherAmount] = useState(false);
     const [otherAmountInput, setOtherAmountInput] = useState('');
-    const [view, setView] = useState<DrawerView>('details');
+    const [paymentLoading, setPaymentLoading] = useState(false);
+
+    const pagination = usePagination<typeof DrawerPages>('details');
+    const checkoutFormRef = useRef<HTMLFormElement>(null);
 
     const total = useMemo(() => computeTotal(donation), [donation]);
-
     const elementsMode = donation.frequency === 'Monthly' ? 'subscription' : 'payment';
 
     useEffect(() => {
@@ -95,14 +104,43 @@ export const DonateButton = ({
         });
         setShowOtherAmount(false);
         setOtherAmountInput('');
-        setView('details');
-    }, [projectName, pageID]);
+        pagination.reset();
+    }, [projectName, pageID, pagination]);
 
     const handleSuccess = useCallback(() => {
         const name = donation.anonymous ? 'Anonymous' : 'Donor';
         handleClose();
         router.replace(`/${pageID}?thanks=${encodeURIComponent(name)}`);
     }, [handleClose, donation.anonymous, pageID, router]);
+
+    const estFee = useMemo(() => estimateFee(donation.amount), [donation.amount]);
+
+    const bottomPanel = useMemo(() => {
+        if (pagination.currentPage === 'details') {
+            return (
+                <Button
+                    onClick={() => pagination.open('payment')}
+                    disabled={donation.amount === 0}
+                    style={{ width: '100%' }}
+                >
+                    {`Continue to Payment \u2014 ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
+                </Button>
+            );
+        }
+        return (
+            <Button
+                onClick={() => {
+                    checkoutFormRef.current?.requestSubmit();
+                }}
+                disabled={paymentLoading}
+                style={{ width: '100%' }}
+            >
+                {paymentLoading
+                    ? 'Processing...'
+                    : `Donate ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
+            </Button>
+        );
+    }, [pagination, donation.amount, donation.frequency, total, paymentLoading]);
 
     return (
         <>
@@ -113,9 +151,11 @@ export const DonateButton = ({
                 Donate
             </Button>
             <Drawer
-                title={view === 'payment' ? 'Payment' : 'Donate'}
+                title="Donate"
                 isOpen={drawerOpen}
                 onClose={() => handleClose()}
+                pagination={pagination}
+                bottomPanel={bottomPanel}
             >
                 <Elements
                     key={`${elementsMode}-${donation.frequency}`}
@@ -124,26 +164,23 @@ export const DonateButton = ({
                         mode: elementsMode,
                         amount: Math.max(total, 50),
                         currency: 'usd',
-                        appearance: {
-                            theme: 'stripe',
-                            variables: {
-                                borderRadius: '8px',
-                            },
-                        },
+                        appearance: STRIPE_APPEARANCE,
                     }}
                 >
                     {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
-                    <DonateDrawerContent
+                    <DonateDrawerInner
                         donation={donation}
                         setDonation={setDonation}
                         showOtherAmount={showOtherAmount}
                         setShowOtherAmount={setShowOtherAmount}
                         otherAmountInput={otherAmountInput}
                         setOtherAmountInput={setOtherAmountInput}
-                        view={view}
-                        setView={setView}
                         total={total}
+                        estFee={estFee}
                         onSuccess={handleSuccess}
+                        checkoutFormRef={checkoutFormRef}
+                        setPaymentLoading={setPaymentLoading}
+                        currentPage={pagination.currentPage}
                     />
                 </Elements>
             </Drawer>
@@ -152,20 +189,27 @@ export const DonateButton = ({
 };
 
 /**
- * Inner component that renders inside <Elements>.
- * Needed because useStripe/useElements can only be called within the Elements provider.
+ * Inner component rendered inside <Elements>.
+ * Since the Drawer with pagination expects keyed children, but we need
+ * useStripe/useElements hooks, we render inside Elements and output
+ * the keyed page divs directly for the Drawer's pagination to pick up.
+ *
+ * NOTE: The Drawer matches children by their React `key` prop against
+ * pagination.currentPage. We return a flat array of keyed divs.
  */
-const DonateDrawerContent = ({
+const DonateDrawerInner = ({
     donation,
     setDonation,
     showOtherAmount,
     setShowOtherAmount,
     otherAmountInput,
     setOtherAmountInput,
-    view,
-    setView,
     total,
+    estFee,
     onSuccess,
+    checkoutFormRef,
+    setPaymentLoading,
+    currentPage,
 }: {
     donation: DonationConfig;
     setDonation: React.Dispatch<React.SetStateAction<DonationConfig>>;
@@ -173,20 +217,14 @@ const DonateDrawerContent = ({
     setShowOtherAmount: (v: boolean) => void;
     otherAmountInput: string;
     setOtherAmountInput: (v: string) => void;
-    view: DrawerView;
-    setView: (v: DrawerView) => void;
     total: number;
+    estFee: number;
     onSuccess: () => void;
+    checkoutFormRef: React.RefObject<HTMLFormElement | null>;
+    setPaymentLoading: (v: boolean) => void;
+    currentPage: string;
 }) => {
-    const stripe = useStripe();
     const elements = useElements();
-
-    const [expressCheckoutReady, setExpressCheckoutReady] = useState(false);
-    const [expressError, setExpressError] = useState<string | null>(null);
-    const [expressLoading, setExpressLoading] = useState(false);
-
-    const estFee = useMemo(() => estimateFee(donation.amount), [donation.amount]);
-    const feeAmount = donation.coverFees ? estFee : 0;
 
     // Keep Elements amount in sync with donation total
     useEffect(() => {
@@ -204,73 +242,9 @@ const DonateDrawerContent = ({
         [],
     );
 
-    const createIntentAndConfirm = useCallback(async () => {
-        if (!stripe || !elements) return;
-
-        const { error: submitError } = await elements.submit();
-        if (submitError) {
-            throw new Error(submitError.message ?? 'Validation failed');
-        }
-
-        const res = await fetch('/v1/donations/create-intent', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                ...donation,
-                amount: donation.amount + feeAmount,
-            }),
-        });
-
-        if (!res.ok) {
-            const data = await res.json().catch(() => null);
-            throw new Error(data?.message ?? 'Failed to create payment');
-        }
-
-        const { clientSecret } = await res.json();
-
-        const { error: confirmError } = await stripe.confirmPayment({
-            elements,
-            clientSecret,
-            confirmParams: {
-                return_url: returnUrl,
-            },
-            redirect: 'if_required',
-        });
-
-        if (confirmError) {
-            throw new Error(confirmError.message ?? 'Payment failed');
-        }
-
-        onSuccess();
-    }, [stripe, elements, donation, feeAmount, returnUrl, onSuccess]);
-
-    const handleExpressCheckoutConfirm = useCallback(async (
-        event: StripeExpressCheckoutElementConfirmEvent,
-    ) => {
-        setExpressLoading(true);
-        setExpressError(null);
-        try {
-            await createIntentAndConfirm();
-        } catch (e) {
-            event.paymentFailed({ reason: 'fail' });
-            setExpressError(e instanceof Error ? e.message : 'Payment failed');
-        } finally {
-            setExpressLoading(false);
-        }
-    }, [createIntentAndConfirm]);
-
-    const handleExpressCheckoutReady = useCallback((
-        event: StripeExpressCheckoutElementReadyEvent,
-    ) => {
-        const methods = event.availablePaymentMethods;
-        setExpressCheckoutReady(
-            Boolean(methods && (methods.applePay || methods.googlePay || methods.link)),
-        );
-    }, []);
-
     return (
         <>
-            {view === 'details' && (
+            {currentPage === 'details' && (
                 <div className="w-full flex flex-col gap-6">
                     <ButtonGroup
                         options={FrequencyOptions.map((f) => ({ id: f, name: f }))}
@@ -461,74 +435,17 @@ const DonateDrawerContent = ({
                             </div>
                         ) : null}
                     </div>
-
-                    {/* Express Checkout (Apple Pay, Google Pay, Link) */}
-                    {expressCheckoutReady && donation.amount > 0 && (
-                        <div className="flex flex-col gap-2">
-                            <div className="flex items-center gap-3">
-                                <div className="flex-1 h-px bg-gray-200" />
-                                <Text kind="paragraphXSmall" style={{ color: '#6b7280' }}>
-                                    Express checkout
-                                </Text>
-                                <div className="flex-1 h-px bg-gray-200" />
-                            </div>
-                            <ExpressCheckoutElement
-                                onConfirm={handleExpressCheckoutConfirm}
-                                onReady={handleExpressCheckoutReady}
-                                options={{
-                                    buttonType: {
-                                        applePay: 'donate',
-                                        googlePay: 'donate',
-                                    },
-                                }}
-                            />
-                            {expressError && (
-                                <Text kind="paragraphXSmall" style={{ color: 'var(--error-color, #dc2626)' }}>
-                                    {expressError}
-                                </Text>
-                            )}
-                        </div>
-                    )}
-
-                    {/* Hidden Express Checkout to detect availability */}
-                    {!expressCheckoutReady && (
-                        <div style={{
-                            position: 'absolute',
-                            opacity: 0,
-                            pointerEvents: 'none',
-                            height: 0,
-                            overflow: 'hidden',
-                        }}
-                        >
-                            <ExpressCheckoutElement
-                                onReady={handleExpressCheckoutReady}
-                                onConfirm={handleExpressCheckoutConfirm}
-                            />
-                        </div>
-                    )}
-
-                    <Button
-                        onClick={() => setView('payment')}
-                        disabled={donation.amount === 0 || expressLoading}
-                    >
-                        {`Continue to Payment \u2014 ${formatCurrency(total, 2)}${donation.frequency === 'One-time' ? '' : ' / month'}`}
-                    </Button>
                 </div>
             )}
 
-            {view === 'payment' && (
-                <div className="w-full flex flex-col gap-4">
-                    <Button
-                        kind="tertiary"
-                        size="small"
-                        onClick={() => setView('details')}
-                    >
-                        &larr; Back to details
-                    </Button>
+            {currentPage === 'payment' && (
+                <div className="w-full">
                     <CheckoutForm
+                        ref={checkoutFormRef as React.Ref<HTMLFormElement>}
                         donation={donation}
                         onSuccess={onSuccess}
                         returnUrl={returnUrl}
+                        onLoadingChange={setPaymentLoading}
                     />
                 </div>
             )}

--- a/src/app/(frontend)/[pageID]/page.tsx
+++ b/src/app/(frontend)/[pageID]/page.tsx
@@ -43,7 +43,7 @@ export default async function DonationPage(
     { params }: { params: { pageID: string } },
 ) {
     const page = await getPage(params.pageID);
-    const recentDonations = await listDonations({
+    const rawDonations = await listDonations({
         include: {
             donor: true,
         },
@@ -53,6 +53,14 @@ export default async function DonationPage(
         limit: 30,
         sort: [desc(donations.createdAt)],
     }) as Array<Donation & { donor: Donor }>;
+
+    // Strip donor PII for anonymous donations so it never reaches the client
+    const anonymousDonor: Donor = {
+        id: '', firstName: 'Anonymous', lastName: 'Donor', email: '', anonymous: true, phone: null, company: null, createdAt: new Date(), updatedAt: new Date(),
+    };
+    const recentDonations = rawDonations.map((d) => (
+        d.visible ? d : { ...d, donor: anonymousDonor }
+    ));
 
     if (page.status === 'draft') {
         return notFound();

--- a/src/db/ops/donations/upsertDonation.ts
+++ b/src/db/ops/donations/upsertDonation.ts
@@ -90,6 +90,10 @@ export const upsertDonation = async (
         }
 
         const donationData = {
+            feeCovered: false,
+            message: null,
+            externalTransactionProvider: null,
+            externalTransactionID: null,
             ...validated,
             donorID: donorData.id,
             id,

--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -1,0 +1,5 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+export const stripePromise = loadStripe(
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
+);

--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -2,4 +2,7 @@ import { loadStripe } from '@stripe/stripe-js';
 
 export const stripePromise = loadStripe(
     process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
+    process.env.NEXT_PUBLIC_STRIPE_ACCOUNT_ID
+        ? { stripeAccount: process.env.NEXT_PUBLIC_STRIPE_ACCOUNT_ID }
+        : undefined,
 );


### PR DESCRIPTION
## Summary

- Replaces the Stripe Checkout Sessions redirect flow with an **inline Payment Element** + **Express Checkout** (Apple Pay, Google Pay, Link) inside the existing paris Drawer
- Uses the **deferred intent pattern**: Elements initialized client-side with `mode/amount/currency`, PaymentIntent or Subscription created server-side only at confirmation time
- **Paginated drawer**: Page 1 has donation config + Express Checkout (wallet users pay in one step), Page 2 has Payment Element for card/other methods
- New `POST /v1/donations/create-intent` endpoint handles both one-time (PaymentIntent) and monthly (Customer + Subscription) donations
- Adds `payment_intent.succeeded` webhook handler for one-time donations alongside existing `invoice.paid` for subscriptions
- Fixes pre-existing bug where `anonymous` field was inverted in the `invoice.paid` webhook handler

## Setup required

- Add `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` to `.env.local` with your Stripe publishable key
- Register `payment_intent.succeeded` event in Stripe Dashboard webhook settings

## Test plan

- [ ] One-time donation: select amount → Continue to Payment → enter test card `4242424242424242` → confirm → ThanksDialog appears
- [ ] Express Checkout: select amount → tap Apple/Google Pay → wallet sheet shows correct total → payment completes inline
- [ ] Monthly donation: select Monthly → complete payment → subscription created in Stripe Dashboard
- [ ] Amount changes: changing amount/fees/tip updates Express Checkout wallet amount in real-time
- [ ] Zero tip: one-time and monthly donations with tip=0% complete without errors
- [ ] Frequency switch: toggling One-time ↔ Monthly correctly reinitializes Elements
- [ ] Webhook: one-time fires `payment_intent.succeeded`, monthly fires `invoice.paid` — both upsert donation correctly