### PR TITLE
feat: add full fundraiser refund endpoint

### DIFF
--- a/src/app/(api)/v1/external/stripe/route.ts
+++ b/src/app/(api)/v1/external/stripe/route.ts
@@ -7,6 +7,9 @@ import type Stripe from 'stripe';
 import { z } from 'zod';
 import { generateID, Prefixes } from 'src/util/generateID';
 import { upsertDonation } from '@db/ops/donations/upsertDonation';
+import { db } from '@db/init';
+import { donations } from '@db/schema';
+import { eq } from 'drizzle-orm';
 
 const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 if (!stripeWebhookSecret) throw new Error('Missing STRIPE_WEBHOOK_SECRET. Please add it to your environment.');
@@ -99,6 +102,23 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                 );
 
                 return NextResponse.json(donation, { status: 201 });
+            }
+            case 'charge.refunded': {
+                const charge = event.data.object as Stripe.Charge;
+                const paymentIntentID = typeof charge.payment_intent === 'string'
+                    ? charge.payment_intent
+                    : charge.payment_intent?.id;
+
+                if (!paymentIntentID) {
+                    throw new HappinessError('Refund event missing payment_intent', 400, { charge: charge.id });
+                }
+
+                // Mark the donation as refunded by its external transaction ID
+                const result = await db.update(donations)
+                    .set({ refunded: true })
+                    .where(eq(donations.externalTransactionID, paymentIntentID));
+
+                return NextResponse.json({ refunded: paymentIntentID }, { status: 200 });
             }
             default: {
                 // Unexpected event type, log and ignore it

--- a/src/app/(api)/v1/pages/[id]/refund/route.ts
+++ b/src/app/(api)/v1/pages/[id]/refund/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { authorize } from '@v1/middleware/authorize';
+import { ErrorResponse } from '@v1/responses/ErrorResponse';
+import { handleErrors } from '@v1/responses/handleErrors';
+import { getPage } from '@db/ops/pages/getPage';
+import { updatePage } from '@db/ops/pages/updatePage';
+import { listDonations } from '@db/ops/donations/listDonations';
+import { refundPaymentIntent } from '@lib/stripe/refundPaymentIntent';
+import { db } from '@db/init';
+import { donations } from '@db/schema';
+import { eq } from 'drizzle-orm';
+
+const STRIPE_REFUND_WINDOW_DAYS = 180;
+
+export const POST = async (
+    request: Request,
+    { params }: { params: { id: string } },
+): Promise<NextResponse> => {
+    try {
+        if (!await authorize(request, 'root')) {
+            return ErrorResponse.unauthorized().json;
+        }
+
+        const { id } = params;
+
+        // Ensure the page exists
+        const page = await getPage(id);
+
+        // Fetch all donations for this page
+        const allDonations = await listDonations({
+            filter: { page: page.id },
+        });
+
+        const refundCutoff = new Date();
+        refundCutoff.setDate(refundCutoff.getDate() - STRIPE_REFUND_WINDOW_DAYS);
+
+        const results: {
+            refunded: string[];
+            skippedAlreadyRefunded: string[];
+            skippedNoTransaction: string[];
+            skippedTooOld: string[];
+            failed: { id: string; error: string }[];
+            totalRefundedAmount: number;
+        } = {
+            refunded: [],
+            skippedAlreadyRefunded: [],
+            skippedNoTransaction: [],
+            skippedTooOld: [],
+            failed: [],
+            totalRefundedAmount: 0,
+        };
+
+        for (const donation of allDonations) {
+            if (donation.refunded) {
+                results.skippedAlreadyRefunded.push(donation.id);
+                continue;
+            }
+
+            if (!donation.externalTransactionID || donation.externalTransactionProvider !== 'stripe') {
+                results.skippedNoTransaction.push(donation.id);
+                continue;
+            }
+
+            if (donation.createdAt < refundCutoff) {
+                results.skippedTooOld.push(donation.id);
+                continue;
+            }
+
+            try {
+                await refundPaymentIntent(donation.externalTransactionID);
+                await db.update(donations)
+                    .set({ refunded: true })
+                    .where(eq(donations.id, donation.id));
+                results.refunded.push(donation.id);
+                results.totalRefundedAmount += donation.amount;
+            } catch (e) {
+                results.failed.push({
+                    id: donation.id,
+                    error: e instanceof Error ? e.message : 'Unknown error',
+                });
+            }
+        }
+
+        // Set page to inactive after refunding
+        await updatePage(page.id, { status: 'inactive' });
+
+        return NextResponse.json({
+            pageID: page.id,
+            status: 'inactive',
+            ...results,
+        });
+    } catch (e) {
+        return handleErrors(e);
+    }
+};

--- a/src/app/(api)/v1/pages/[id]/refund/route.ts
+++ b/src/app/(api)/v1/pages/[id]/refund/route.ts
@@ -34,52 +34,53 @@ export const POST = async (
         const refundCutoff = new Date();
         refundCutoff.setDate(refundCutoff.getDate() - STRIPE_REFUND_WINDOW_DAYS);
 
-        const results: {
-            refunded: string[];
-            skippedAlreadyRefunded: string[];
-            skippedNoTransaction: string[];
-            skippedTooOld: string[];
-            failed: { id: string; error: string }[];
-            totalRefundedAmount: number;
-        } = {
-            refunded: [],
-            skippedAlreadyRefunded: [],
-            skippedNoTransaction: [],
-            skippedTooOld: [],
-            failed: [],
-            totalRefundedAmount: 0,
-        };
+        const skippedAlreadyRefunded = allDonations
+            .filter((d) => d.refunded)
+            .map((d) => d.id);
 
-        for (const donation of allDonations) {
-            if (donation.refunded) {
-                results.skippedAlreadyRefunded.push(donation.id);
-                continue;
-            }
+        const skippedNoTransaction = allDonations
+            .filter((d) => !d.refunded && (!d.externalTransactionID || d.externalTransactionProvider !== 'stripe'))
+            .map((d) => d.id);
 
-            if (!donation.externalTransactionID || donation.externalTransactionProvider !== 'stripe') {
-                results.skippedNoTransaction.push(donation.id);
-                continue;
-            }
+        const skippedTooOld = allDonations
+            .filter((d) => !d.refunded && d.externalTransactionID && d.externalTransactionProvider === 'stripe' && d.createdAt < refundCutoff)
+            .map((d) => d.id);
 
-            if (donation.createdAt < refundCutoff) {
-                results.skippedTooOld.push(donation.id);
-                continue;
-            }
+        const refundable = allDonations
+            .filter((d) => !d.refunded && d.externalTransactionID && d.externalTransactionProvider === 'stripe' && d.createdAt >= refundCutoff);
 
-            try {
-                await refundPaymentIntent(donation.externalTransactionID);
+        const refundResults = await Promise.allSettled(
+            refundable.map(async (donation) => {
+                await refundPaymentIntent(donation.externalTransactionID!);
                 await db.update(donations)
                     .set({ refunded: true })
                     .where(eq(donations.id, donation.id));
-                results.refunded.push(donation.id);
-                results.totalRefundedAmount += donation.amount;
-            } catch (e) {
-                results.failed.push({
-                    id: donation.id,
-                    error: e instanceof Error ? e.message : 'Unknown error',
-                });
-            }
-        }
+                return donation;
+            }),
+        );
+
+        const results = refundResults.reduce(
+            (acc, result, i) => {
+                if (result.status === 'fulfilled') {
+                    acc.refunded.push(result.value.id);
+                    acc.totalRefundedAmount += result.value.amount;
+                } else {
+                    acc.failed.push({
+                        id: refundable[i].id,
+                        error: result.reason instanceof Error ? result.reason.message : 'Unknown error',
+                    });
+                }
+                return acc;
+            },
+            {
+                refunded: [] as string[],
+                skippedAlreadyRefunded,
+                skippedNoTransaction,
+                skippedTooOld,
+                failed: [] as { id: string; error: string }[],
+                totalRefundedAmount: 0,
+            },
+        );
 
         // Set page to inactive after refunding
         await updatePage(page.id, { status: 'inactive' });

--- a/src/db/ops/donations/upsertDonation.ts
+++ b/src/db/ops/donations/upsertDonation.ts
@@ -73,6 +73,22 @@ export const upsertDonation = async (
             });
         }
 
+        // If the donation already exists and has been refunded, skip the update
+        if (validated.id) {
+            const existing = await tx.query.donations.findFirst({
+                where: eq(donations.id, validated.id),
+                columns: { refunded: true },
+            });
+            if (existing?.refunded) {
+                try {
+                    tx.rollback();
+                } catch (e) {
+                    // Graceful catch so we can throw a more helpful error
+                }
+                throw new HappinessError('Donation has been refunded and cannot be updated', 409, { id: validated.id });
+            }
+        }
+
         const donationData = {
             ...validated,
             donorID: donorData.id,

--- a/src/db/ops/pages/getPage.ts
+++ b/src/db/ops/pages/getPage.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { selectPageSchema, pages, donations } from '@db/schema';
 import { db } from '@db/init';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { HappinessError } from 'src/util/HappinessError';
 import { validateReturn } from '@db/ops/shared';
 import { Prefixes } from 'src/util/generateID';
@@ -26,7 +26,7 @@ export const getPage = async (search: string): Promise<z.infer<typeof selectPage
             raised: sql<number>`sum(${donations.amount})`,
         })
         .from(donations)
-        .where(eq(donations.pageID, query.id));
+        .where(and(eq(donations.pageID, query.id), eq(donations.refunded, false)));
 
     return validateReturn(selectPageSchema, {
         ...query,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -52,6 +52,7 @@ export const DonationsColumns = {
     message: text('message'),
     externalTransactionProvider: mysqlEnum('external_transaction_provider', ['stripe']),
     externalTransactionID: varchar('external_transaction_id', { length: 255 }).unique(),
+    refunded: boolean('refunded').notNull().default(false),
 } as const;
 
 export const donations = mysqlTable('donations', DonationsColumns);

--- a/src/lib/stripe/refundPaymentIntent.ts
+++ b/src/lib/stripe/refundPaymentIntent.ts
@@ -1,0 +1,12 @@
+import { stripe } from '@lib/stripe';
+
+/**
+ * Refunds a Stripe payment intent in full.
+ * @param paymentIntentID - The Stripe payment intent ID to refund.
+ * @returns The created Stripe refund object.
+ */
+export const refundPaymentIntent = async (paymentIntentID: string) => {
+    return stripe.refunds.create({
+        payment_intent: paymentIntentID,
+    });
+};

--- a/src/lib/stripe/refundPaymentIntent.ts
+++ b/src/lib/stripe/refundPaymentIntent.ts
@@ -5,8 +5,6 @@ import { stripe } from '@lib/stripe';
  * @param paymentIntentID - The Stripe payment intent ID to refund.
  * @returns The created Stripe refund object.
  */
-export const refundPaymentIntent = async (paymentIntentID: string) => {
-    return stripe.refunds.create({
-        payment_intent: paymentIntentID,
-    });
-};
+export const refundPaymentIntent = async (paymentIntentID: string) => stripe.refunds.create({
+    payment_intent: paymentIntentID,
+});


### PR DESCRIPTION
Add POST /v1/pages/:id/refund to refund all donations for a fundraiser via Stripe, with a refunded column on donations to exclude them from raised totals. Includes charge.refunded webhook handler and upsert guard to prevent overwriting refunded donations.