### PR TITLE
feat: add endpoint to resend donation receipt email

### DIFF
--- a/src/app/(api)/api/oas/index.ts
+++ b/src/app/(api)/api/oas/index.ts
@@ -4,6 +4,7 @@ import { IDParameter } from '@docs/oas/schemas/id';
 import { PageSchema } from '@docs/oas/schemas/pages';
 import { bearerAuth } from '@docs/oas/schemas/security';
 import { ErrorResponses, ErrorSchema } from '@docs/oas/shared/errorResponses';
+import { DONATIONS_ID_RECEIPT_EMAIL_POST_SCHEMA } from '@v1/donations/[id]/receipt/email/schemas';
 import { DONATIONS_ID_GET_SCHEMA } from '@v1/donations/[id]/schemas';
 import {
     DONATIONS_GET_SCHEMA,
@@ -72,6 +73,9 @@ export const oas = new OpenApiBuilder({
         },
         '/v1/donations/{id}': {
             get: DONATIONS_ID_GET_SCHEMA,
+        },
+        '/v1/donations/{id}/receipt/email': {
+            post: DONATIONS_ID_RECEIPT_EMAIL_POST_SCHEMA,
         },
     },
 });

--- a/src/app/(api)/v1/donations/[id]/receipt/email/route.ts
+++ b/src/app/(api)/v1/donations/[id]/receipt/email/route.ts
@@ -1,0 +1,71 @@
+import { getDonation } from '@db/ops/donations/getDonation';
+import type { Donor, Page } from '@db/schema';
+import { sendDonationConfirmation } from '@lib/email/sendDonationConfirmation';
+import { authorize } from '@v1/middleware/authorize';
+import { ErrorResponse } from '@v1/responses/ErrorResponse';
+import { handleErrors } from '@v1/responses/handleErrors';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const bodySchema = z.object({
+    email: z.string().email().optional(),
+});
+
+/**
+ * Resends the donation receipt confirmation email. Optionally accepts an
+ * `email` override; if omitted, the donor's email on file is used. The override
+ * is one-off and does not modify the donor record.
+ */
+export const POST = async (
+    request: Request,
+    props: { params: Promise<{ id: string }> },
+) => {
+    const params = await props.params;
+    try {
+        if (!(await authorize(request, 'root'))) {
+            return ErrorResponse.unauthorized().json;
+        }
+
+        const rawBody = await request.json().catch(() => ({}));
+        const { email: overrideEmail } = bodySchema.parse(rawBody);
+
+        const donation = (await getDonation(params.id, {
+            include: { donor: true, page: true },
+        })) as Awaited<ReturnType<typeof getDonation>> & {
+            donor?: Donor;
+            page?: Page;
+        };
+
+        if (!donation.donor) {
+            return ErrorResponse.badRequest('Donation has no associated donor')
+                .json;
+        }
+        if (!donation.page) {
+            return ErrorResponse.badRequest('Donation has no associated page')
+                .json;
+        }
+
+        const targetEmail = overrideEmail ?? donation.donor.email;
+        if (!targetEmail || targetEmail.endsWith('@donor.noemail')) {
+            return ErrorResponse.badRequest(
+                'Donor has no real email on file; provide an `email` override',
+            ).json;
+        }
+
+        await sendDonationConfirmation({
+            donationID: donation.id,
+            donorEmail: targetEmail,
+            donorName: donation.donor.firstName || 'Donor',
+            amount: donation.amount,
+            amountCurrency: donation.amountCurrency,
+            campaignName: donation.page.name,
+            organizer: donation.page.organizer,
+            fsProject: donation.page.fsProject ?? null,
+            date: donation.createdAt ?? new Date(),
+        });
+
+        return NextResponse.json({ ok: true, sentTo: targetEmail });
+    } catch (e) {
+        return handleErrors(e);
+    }
+};

--- a/src/app/(api)/v1/donations/[id]/receipt/email/schemas.ts
+++ b/src/app/(api)/v1/donations/[id]/receipt/email/schemas.ts
@@ -1,0 +1,64 @@
+import { security } from '@docs/oas/schemas/security';
+import { errorResponses } from '@docs/oas/shared/errorResponses';
+import type { OperationObject } from 'openapi3-ts/oas30';
+
+export const DONATIONS_ID_RECEIPT_EMAIL_POST_SCHEMA: OperationObject = {
+    operationId: 'resendDonationReceiptEmail',
+    summary: 'Resend donation receipt email',
+    description:
+        "Resends the donation receipt confirmation email for a specific donation. If `email` is provided in the body, the receipt is sent to that address instead of the donor's email on file. The override is one-off and does not modify the donor record.",
+    tags: ['Donations'],
+    parameters: [
+        {
+            $ref: '#/components/parameters/id',
+        },
+    ],
+    requestBody: {
+        description:
+            "Optional override email address. If omitted, the donor's email on file is used.",
+        required: false,
+        content: {
+            'application/json': {
+                schema: {
+                    type: 'object',
+                    properties: {
+                        email: {
+                            type: 'string',
+                            format: 'email',
+                            description:
+                                "Override email address to send the receipt to. If omitted, the donor's email on file is used.",
+                            example: 'donor@example.com',
+                        },
+                    },
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            description:
+                'Receipt email was sent successfully. Returns the address it was sent to.',
+            content: {
+                'application/json': {
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            ok: {
+                                type: 'boolean',
+                                example: true,
+                            },
+                            sentTo: {
+                                type: 'string',
+                                format: 'email',
+                                example: 'donor@example.com',
+                            },
+                        },
+                        required: ['ok', 'sentTo'],
+                    },
+                },
+            },
+        },
+        ...errorResponses([400, 401, 404, 500]),
+    },
+    security,
+};

--- a/src/lib/email/sendDonationConfirmation.ts
+++ b/src/lib/email/sendDonationConfirmation.ts
@@ -57,10 +57,7 @@ export async function sendDonationConfirmation(
 ): Promise<void> {
     const transporter = getTransporter();
     if (!transporter) {
-        console.warn(
-            '[email] SMTP not configured, skipping donation confirmation email',
-        );
-        return;
+        throw new Error('SMTP not configured');
     }
 
     const {
@@ -146,18 +143,14 @@ ${appName}`;
   <p style="color: #9ca3af; font-size: 13px; margin-top: 32px;">Thank you for your support!<br>${appName}</p>
 </div>`;
 
-    try {
-        await transporter.sendMail({
-            from: process.env.SMTP_FROM,
-            to: donorEmail,
-            subject: `Donation confirmation — ${amountStr} to ${campaignName}`,
-            text: textBody,
-            html: htmlBody,
-        });
-        console.log(
-            `[email] Donation confirmation sent to ${donorEmail} for ${donationID}`,
-        );
-    } catch (err) {
-        console.error('[email] Failed to send donation confirmation:', err);
-    }
+    await transporter.sendMail({
+        from: process.env.SMTP_FROM,
+        to: donorEmail,
+        subject: `Donation confirmation — ${amountStr} to ${campaignName}`,
+        text: textBody,
+        html: htmlBody,
+    });
+    console.log(
+        `[email] Donation confirmation sent to ${donorEmail} for ${donationID}`,
+    );
 }


### PR DESCRIPTION
## Summary
- New endpoint `POST /v1/donations/{id}/receipt/email` (root-auth) for resending the donation confirmation email
- Optional `email` body field overrides the recipient as a one-off; donor record is not modified
- Refactors `sendDonationConfirmation` to throw on SMTP misconfig/send failures so the endpoint can surface errors. Stripe webhook caller already catches and logs, so its behavior is preserved

## Request shape
```
POST /v1/donations/{id}/receipt/email
Authorization: Bearer <root key>
Content-Type: application/json

{ "email"?: "donor@example.com" }   // optional override
```

Returns `200 { ok: true, sentTo: "<email>" }` on success.

Errors:
- 400 — invalid body, missing donor/page, or donor has no real email and no override provided
- 401 — unauthorized
- 404 — donation not found
- 500 — SMTP not configured or send failed

## Test plan
- [ ] Curl with valid donation ID and no body → email sent to donor's email on file
- [ ] Curl with `{ "email": "other@example.com" }` → email sent to override; donor record unchanged
- [ ] Curl with invalid email in body → 400
- [ ] Curl on donation whose donor has `@donor.noemail` placeholder and no override → 400
- [ ] Curl without Authorization header → 401
- [ ] Curl with unknown donation ID → 404
- [ ] Confirm Stripe webhook flow still sends confirmation emails (regression check)
- [ ] OpenAPI docs page renders the new endpoint at `/api`