### PR TITLE
feat: redact anonymous donor PII in listDonations (refs ENG-1971)

### DIFF
--- a/e2e/api/donations.spec.ts
+++ b/e2e/api/donations.spec.ts
@@ -1,10 +1,31 @@
 import { expect, test } from '@playwright/test';
 import { api } from '../helpers/api-client';
 import {
+    ANON_DONATION_ID,
+    ANON_DONOR_EMAIL,
+    ANON_DONOR_FIRST,
     BASE_URL,
     SIMPLE_PAGE_ID,
     TEST_DONATION_ID,
+    TEST_DONOR_EMAIL,
 } from '../helpers/fixtures';
+
+type DonationRow = {
+    id: string;
+    amount: number;
+    donor?: {
+        firstName: string | null;
+        lastName: string | null;
+        company: string | null;
+        email: string | null;
+        phone: string | null;
+        anonymous: boolean;
+    };
+    page?: { id: string };
+};
+
+const findByID = (rows: unknown, id: string): DonationRow | undefined =>
+    (rows as DonationRow[]).find((d) => d.id === id);
 
 test.describe('Donations API', () => {
     test('GET /v1/donations with auth — returns array', async () => {
@@ -96,5 +117,63 @@ test.describe('Donations API', () => {
         expect(status).toBe(200);
         expect(result.clientSecret).toBeTruthy();
         expect(result.donationID).toBeTruthy();
+    });
+
+    test('GET /v1/donations?include=donor&redactAnonymous=true — redacts anonymous PII, keeps non-anonymous', async () => {
+        const { status, data } = await api.listDonations({
+            include: 'donor',
+            page: SIMPLE_PAGE_ID,
+            redactAnonymous: 'true',
+        });
+        expect(status).toBe(200);
+
+        const anon = findByID(data, ANON_DONATION_ID);
+        expect(anon).toBeTruthy();
+        // Anonymous donor's PII is nulled at the DB layer...
+        expect(anon?.donor?.anonymous).toBe(true);
+        expect(anon?.donor?.firstName).toBeNull();
+        expect(anon?.donor?.lastName).toBeNull();
+        expect(anon?.donor?.company).toBeNull();
+        expect(anon?.donor?.email).toBeNull();
+        expect(anon?.donor?.phone).toBeNull();
+        // ...but the donation row itself is intact.
+        expect(anon?.amount).toBe(2500);
+
+        // The non-anonymous donor's PII is still returned.
+        const regular = findByID(data, TEST_DONATION_ID);
+        expect(regular?.donor?.anonymous).toBe(false);
+        expect(regular?.donor?.email).toBe(TEST_DONOR_EMAIL);
+        expect(regular?.donor?.firstName).toBeTruthy();
+
+        // The redacted PII must not leak anywhere in the payload.
+        const raw = JSON.stringify(data);
+        expect(raw).not.toContain(ANON_DONOR_EMAIL);
+        expect(raw).not.toContain(ANON_DONOR_FIRST);
+    });
+
+    test('GET /v1/donations?include=donor (no redactAnonymous) — anonymous PII returned (default unchanged)', async () => {
+        const { status, data } = await api.listDonations({
+            include: 'donor',
+            page: SIMPLE_PAGE_ID,
+        });
+        expect(status).toBe(200);
+
+        const anon = findByID(data, ANON_DONATION_ID);
+        expect(anon?.donor?.anonymous).toBe(true);
+        expect(anon?.donor?.email).toBe(ANON_DONOR_EMAIL);
+        expect(anon?.donor?.firstName).toBe(ANON_DONOR_FIRST);
+    });
+
+    test('GET /v1/donations?include=donor,page&redactAnonymous=true — page still included', async () => {
+        const { status, data } = await api.listDonations({
+            include: 'donor,page',
+            page: SIMPLE_PAGE_ID,
+            redactAnonymous: 'true',
+        });
+        expect(status).toBe(200);
+
+        const anon = findByID(data, ANON_DONATION_ID);
+        expect(anon?.donor?.firstName).toBeNull();
+        expect(anon?.page?.id).toBe(SIMPLE_PAGE_ID);
     });
 });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -12,6 +12,13 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '.env.test' });
 
 import {
+    ANON_DONATION_ID,
+    ANON_DONOR_COMPANY,
+    ANON_DONOR_EMAIL,
+    ANON_DONOR_FIRST,
+    ANON_DONOR_ID,
+    ANON_DONOR_LAST,
+    ANON_DONOR_PHONE,
     SIMPLE_PAGE_ID,
     SIMPLE_PAGE_SLUG,
     STORY_PAGE_ID,
@@ -152,6 +159,44 @@ async function seedTestData() {
             'E2E test donation',
             'stripe',
             'pi_e2e_test_seed_001',
+        ],
+    );
+
+    // Insert anonymous donor (PII present in DB, but flagged anonymous)
+    await pool.query(
+        `INSERT INTO \`${prefix}_donors\` (id, first_name, last_name, company, email, phone, anonymous)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE email = VALUES(email)`,
+        [
+            ANON_DONOR_ID,
+            ANON_DONOR_FIRST,
+            ANON_DONOR_LAST,
+            ANON_DONOR_COMPANY,
+            ANON_DONOR_EMAIL,
+            ANON_DONOR_PHONE,
+            true,
+        ],
+    );
+
+    // Insert donation from the anonymous donor on the simple page
+    await pool.query(
+        `INSERT INTO \`${prefix}_donations\` (id, page_id, donor_id, amount, amount_currency, fee, fee_currency, fee_covered, tip_amount, visible, message, external_transaction_provider, external_transaction_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE id = VALUES(id)`,
+        [
+            ANON_DONATION_ID,
+            SIMPLE_PAGE_ID,
+            ANON_DONOR_ID,
+            2500, // $25.00
+            'usd',
+            75, // $0.75 fee
+            'usd',
+            false,
+            0,
+            false, // anonymous donations are not publicly visible
+            'E2E anonymous donation',
+            'stripe',
+            'pi_e2e_test_seed_anon',
         ],
     );
 

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -20,6 +20,13 @@ export const TEST_DONOR_EMAIL = 'e2e-donor@test.local';
 export const TEST_DONOR_FIRST = 'E2E';
 export const TEST_DONOR_LAST = 'Donor';
 
+// Anonymous donor — used to verify redactAnonymous PII redaction.
+export const ANON_DONOR_EMAIL = 'e2e-anon@test.local';
+export const ANON_DONOR_FIRST = 'Anon';
+export const ANON_DONOR_LAST = 'Donor';
+export const ANON_DONOR_COMPANY = 'Anon Co';
+export const ANON_DONOR_PHONE = '+15555550100';
+
 // -- MailPit ----------------------------------------------------------------
 
 export const MAILPIT_URL = 'http://localhost:8025';
@@ -32,3 +39,5 @@ export const SIMPLE_PAGE_ID = 'pg_e2esimple001';
 export const STORY_PAGE_ID = 'pg_e2estory0001';
 export const TEST_DONOR_ID = 'dr_e2edonor0001';
 export const TEST_DONATION_ID = 'dn_e2edonation1';
+export const ANON_DONOR_ID = 'dr_e2eanon00001';
+export const ANON_DONATION_ID = 'dn_e2eanondon01';

--- a/src/app/(api)/v1/donations/route.ts
+++ b/src/app/(api)/v1/donations/route.ts
@@ -22,6 +22,7 @@ export const GET = async (request: Request) => {
 
         const beforeFilter = searchParams.get('before');
         const afterFilter = searchParams.get('after');
+        const redactAnonymous = searchParams.get('redactAnonymous') === 'true';
 
         return NextResponse.json(
             await listDonations({
@@ -36,6 +37,7 @@ export const GET = async (request: Request) => {
                     page: pageFilter,
                     before: beforeFilter ? new Date(beforeFilter) : undefined,
                     after: afterFilter ? new Date(afterFilter) : undefined,
+                    redactAnonymous,
                 },
             }),
         );

--- a/src/app/(api)/v1/donations/schemas.ts
+++ b/src/app/(api)/v1/donations/schemas.ts
@@ -22,6 +22,16 @@ export const DONATIONS_GET_SCHEMA: OperationObject = {
         FilterParam('Page'),
         FilterParam('Donor'),
         ...timestampFilters,
+        {
+            name: 'redactAnonymous',
+            in: 'query',
+            description:
+                "When true, anonymous donors' personally identifiable information (name, company, email, phone) is redacted at the database layer and returned as null. The donation and the donor's `anonymous` flag are still returned. Only takes effect when `donor` is included.",
+            example: '?redactAnonymous=true',
+            schema: {
+                type: 'boolean',
+            },
+        },
     ],
     responses: {
         200: {

--- a/src/db/ops/donations/listDonations.ts
+++ b/src/db/ops/donations/listDonations.ts
@@ -2,12 +2,14 @@ import { db } from '@db/init';
 import { validateID, validateReturn } from '@db/ops/shared';
 import {
     donations,
+    donors,
+    pages,
     selectDonationSchema,
     selectDonorSchema,
     selectPageSchema,
 } from '@db/schema';
 import type { SQL, SQLWrapper } from 'drizzle-orm';
-import { and, eq, gte, lte } from 'drizzle-orm';
+import { and, eq, gte, lte, sql } from 'drizzle-orm';
 import { z } from 'zod';
 
 /**
@@ -31,6 +33,16 @@ export const listDonations = async (options?: {
         before?: Date | null;
         /** Filter donations after a certain date. */
         after?: Date | null;
+        /**
+         * When true, the donor's personally identifiable information
+         * (first name, last name, company, email, phone) is redacted at the
+         * SQL layer for anonymous donors: the query returns NULL for those
+         * columns whenever `donors.anonymous` is true, so anonymous PII is
+         * never read out of the database. The donation row and the donor's
+         * `anonymous` flag are still returned. Only takes effect when the
+         * donor relation is included.
+         */
+        redactAnonymous?: boolean;
     };
     /** The number of results to return. */
     limit?: number;
@@ -57,6 +69,69 @@ export const listDonations = async (options?: {
     }
 
     const where = and(...filters);
+
+    // Redacted path: when redacting anonymous donors' PII, fetch the donor via
+    // explicit SQL CASE expressions so anonymous PII is never read from the DB.
+    // Drizzle's relational query API (used below) can't express per-column CASE
+    // overrides, so this path uses a manual join + select instead.
+    if (options?.filter?.redactAnonymous && options?.include?.donor) {
+        const redact = (column: SQLWrapper) =>
+            sql<
+                string | null
+            >`CASE WHEN ${donors.anonymous} = TRUE THEN NULL ELSE ${column} END`;
+
+        const rows = await db
+            .select({
+                donation: donations,
+                donor: {
+                    id: donors.id,
+                    createdAt: donors.createdAt,
+                    updatedAt: donors.updatedAt,
+                    anonymous: donors.anonymous,
+                    firstName: redact(donors.firstName),
+                    lastName: redact(donors.lastName),
+                    company: redact(donors.company),
+                    email: redact(donors.email),
+                    phone: redact(donors.phone),
+                },
+                page: pages,
+            })
+            .from(donations)
+            // donorID / pageID are non-null FKs, so the related rows always
+            // exist; innerJoin keeps the donor/page columns non-nullable.
+            .innerJoin(donors, eq(donations.donorID, donors.id))
+            .innerJoin(pages, eq(donations.pageID, pages.id))
+            .where(where)
+            .limit(options?.limit ?? Number.MAX_SAFE_INTEGER)
+            .orderBy(...(options?.sort ?? []));
+
+        const shaped = rows.map((row) => ({
+            ...row.donation,
+            donor: row.donor,
+            ...(options?.include?.page ? { page: row.page } : {}),
+        }));
+
+        // Donor PII columns become nullable on the redacted path.
+        const redactedDonorSchema = selectDonorSchema.extend({
+            firstName: selectDonorSchema.shape.firstName.nullable(),
+            lastName: selectDonorSchema.shape.lastName.nullable(),
+            email: selectDonorSchema.shape.email.nullable(),
+        });
+
+        return validateReturn(
+            z.array(
+                selectDonationSchema.merge(
+                    z.object({
+                        donor: redactedDonorSchema,
+                        ...(options?.include?.page
+                            ? { page: selectPageSchema }
+                            : {}),
+                    }),
+                ),
+            ),
+            shaped,
+        );
+    }
 
     const query = await db.query.donations.findMany({
         with: {


### PR DESCRIPTION
Adds a `redactAnonymous` filter to listDonations (and a matching query param on GET /v1/donations). When set with the donor relation included, donor PII (first/last name, company, email, phone) is selected through SQL CASE expressions that return NULL for anonymous donors, so anonymous PII is never read out of the database. The donation row and the donor's `anonymous` flag are still returned. Default behavior is unchanged.